### PR TITLE
Keep walletconnect session alive on init()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
+## [6.4.1]
 -   [Keep WalletConnect session alive if still connected on init() #37](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/37)
 
 ## [6.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
-
+-   [Keep WalletConnect session alive if still connected on init() #37](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/37)
 
 ## [6.4.0]
 -   [Added web wallet token option for login hook #33](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/33)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@elrondnetwork/erdjs",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "description": "Smart Contracts interaction framework",
     "main": "out/index.js",
     "types": "out/index.d.js",

--- a/src/dapp/walletConnectProvider.ts
+++ b/src/dapp/walletConnectProvider.ts
@@ -37,6 +37,15 @@ export class WalletConnectProvider implements IDappProvider {
         this.walletConnector.on("connect", this.onConnect.bind(this));
         this.walletConnector.on("session_update", this.onDisconnect.bind(this));
         this.walletConnector.on("disconnect", this.onDisconnect.bind(this));
+
+        if (
+          this.walletConnector.connected &&
+          this.walletConnector.accounts.length
+        ) {
+          const [account] = this.walletConnector.accounts;
+          this.loginAccount(account);
+        }
+
         return true;
     }
 
@@ -88,9 +97,14 @@ export class WalletConnectProvider implements IDappProvider {
     }
 
     /**
-     * Fetches current selected ledger address
+     * Fetches the wallet connect address
      */
     async getAddress(): Promise<string> {
+        if (!this.walletConnector) {
+            Logger.error("getAddress: Wallet Connect not initialised, call init() first");
+            throw new Error("Wallet Connect not initialised, call init() first");
+        }
+      
         return this.address;
     }
 


### PR DESCRIPTION
In case the walletconnect connection is still alive and the user is still connected, keep the session alive on init() ( useful when the user refreshes the page and calls init() again )