### PR TITLE
Fix message signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [6.5.1]
+-   [Adapted message signing for ledger #42](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/42)
+
 ## [6.5.0]
 -   [Extended SignableMessage to allow export to JSON #40](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/40)
 -   [Bugfix: fixed option decoder #39](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/39)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@elrondnetwork/erdjs",
-    "version": "6.2.0",
+    "version": "6.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@elrondnetwork/erdjs",
-    "version": "6.5.0",
+    "version": "6.5.1",
     "description": "Smart Contracts interaction framework",
     "main": "out/index.js",
     "types": "out/index.d.js",

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -26,6 +26,9 @@ export class Signature {
     }
 
     static fromHex(value: string): Signature {
+        if (value.startsWith("0x")) {
+            value = value.slice(2);
+        }
         if (!Signature.isValidHex(value)) {
             throw new errors.ErrSignatureCannotCreate(value);
         }


### PR DESCRIPTION
Added length as a prefix to the message.
Ledger expects it on 4 bytes. When computing the hash, it needs to be converted to string and only the plain value is used