### PR TITLE
Avoid changing global axios.defaults.transformResponse

### DIFF
--- a/src/apiProvider.ts
+++ b/src/apiProvider.ts
@@ -22,11 +22,17 @@ export class ApiProvider implements IApiProvider {
      * @param url the URL of the Elrond Api
      * @param config axios request config options
      */
-    constructor(url: string, config?: AxiosRequestConfig) {
-        this.url = url;
-        this.config = config || {
-            timeout: 1000,
-        };
+     constructor(url: string, config?: AxiosRequestConfig) {
+      this.url = url;
+      // See: https://github.com/axios/axios/issues/983
+      this.config = config || {
+        timeout: 1000,
+        transformResponse: [
+          function(data) {
+            return JSONbig.parse(data);
+          },
+        ],
+      };
     }
 
     /**
@@ -90,10 +96,3 @@ export class ApiProvider implements IApiProvider {
         throw new errors.ErrApiProviderGet(resourceUrl, originalErrorMessage, error);
     }
 }
-
-// See: https://github.com/axios/axios/issues/983
-axios.defaults.transformResponse = [
-    function (data) {
-        return JSONbig.parse(data);
-    },
-];

--- a/src/apiProvider.ts
+++ b/src/apiProvider.ts
@@ -22,17 +22,17 @@ export class ApiProvider implements IApiProvider {
      * @param url the URL of the Elrond Api
      * @param config axios request config options
      */
-     constructor(url: string, config?: AxiosRequestConfig) {
+    constructor(url: string, config?: AxiosRequestConfig) {
       this.url = url;
-      // See: https://github.com/axios/axios/issues/983
-      this.config = config || {
+      this.config = Object.assign({}, config, {
         timeout: 1000,
+        // See: https://github.com/axios/axios/issues/983 regarding transformResponse
         transformResponse: [
-          function(data) {
+          function(data: any) {
             return JSONbig.parse(data);
           },
         ],
-      };
+      });
     }
 
     /**

--- a/src/proxyProvider.ts
+++ b/src/proxyProvider.ts
@@ -27,8 +27,14 @@ export class ProxyProvider implements IProvider {
      */
     constructor(url: string, config?: AxiosRequestConfig) {
         this.url = url;
+        // See: https://github.com/axios/axios/issues/983
         this.config = config || {
             timeout: 1000,
+            transformResponse: [
+              function(data) {
+                return JSONbig.parse(data);
+              },
+            ],
         };
     }
 
@@ -199,10 +205,3 @@ export class ProxyProvider implements IProvider {
         throw new errors.ErrApiProviderGet(resourceUrl, originalErrorMessage, error);
     }
 }
-
-// See: https://github.com/axios/axios/issues/983
-axios.defaults.transformResponse = [
-    function (data) {
-        return JSONbig.parse(data);
-    },
-];

--- a/src/proxyProvider.ts
+++ b/src/proxyProvider.ts
@@ -27,15 +27,15 @@ export class ProxyProvider implements IProvider {
      */
     constructor(url: string, config?: AxiosRequestConfig) {
         this.url = url;
-        // See: https://github.com/axios/axios/issues/983
-        this.config = config || {
-            timeout: 1000,
-            transformResponse: [
-              function(data) {
-                return JSONbig.parse(data);
-              },
-            ],
-        };
+        this.config = Object.assign({}, config, {
+          timeout: 1000,
+          // See: https://github.com/axios/axios/issues/983 regarding transformResponse
+          transformResponse: [
+            function(data: any) {
+              return JSONbig.parse(data);
+            },
+          ],
+        });
     }
 
     /**


### PR DESCRIPTION
What do you think about isolating the axios config to the local file, rather than changing axios for the global scope?

For example, this is one case of the axios global config change introduced by erdjs that conflicts with arweave.
https://github.com/ElrondNetwork/elrond-sdk-erdjs/issues/46

It could make it easier to integrate elrond/erdjs with more dapps with fewer chances of conflict.