### PR TITLE
Native serializer composite types

### DIFF
--- a/src/smartcontracts/argSerializer.spec.ts
+++ b/src/smartcontracts/argSerializer.spec.ts
@@ -1,16 +1,16 @@
 import { assert } from "chai";
 import {
-  U8Value,
-  EndpointParameterDefinition,
-  TypedValue,
-  U32Value,
-  I64Value,
-  U16Value,
-  OptionValue,
-  List,
-  Tuple,
-  I32Value,
-  I16Value,
+    U8Value,
+    EndpointParameterDefinition,
+    TypedValue,
+    U32Value,
+    I64Value,
+    U16Value,
+    OptionValue,
+    List,
+    Tuple,
+    I32Value,
+    I16Value,
 } from "./typesystem";
 import { ArgSerializer } from "./argSerializer";
 import BigNumber from "bignumber.js";
@@ -21,81 +21,81 @@ import { CompositeValue } from "./typesystem/composite";
 import { VariadicValue } from "./typesystem/variadic";
 
 describe("test serializer", () => {
-  let serializer = new ArgSerializer();
-  let typeParser = new TypeExpressionParser();
-  let typeMapper = new TypeMapper();
+    let serializer = new ArgSerializer();
+    let typeParser = new TypeExpressionParser();
+    let typeMapper = new TypeMapper();
 
-  it("should serialize <valuesToString> then back <stringToValues>", async () => {
-    serializeThenDeserialize(
-      ["u32", "i64", "bytes"],
-      [new U32Value(100), new I64Value(new BigNumber("-1")), new BytesValue(Buffer.from("abba", "hex"))],
-      "64@ff@abba"
-    );
+    it("should serialize <valuesToString> then back <stringToValues>", async () => {
+        serializeThenDeserialize(
+            ["u32", "i64", "bytes"],
+            [new U32Value(100), new I64Value(new BigNumber("-1")), new BytesValue(Buffer.from("abba", "hex"))],
+            "64@ff@abba"
+        );
 
-    serializeThenDeserialize(
-      ["Option<u32>", "Option<u8>", "MultiArg<u8, bytes>"],
-      [
-        OptionValue.newProvided(new U32Value(100)),
-        OptionValue.newMissing(),
-        CompositeValue.fromItems(new U8Value(3), new BytesValue(Buffer.from("abba", "hex"))),
-      ],
-      "0100000064@@03@abba"
-    );
+        serializeThenDeserialize(
+            ["Option<u32>", "Option<u8>", "MultiArg<u8, bytes>"],
+            [
+                OptionValue.newProvided(new U32Value(100)),
+                OptionValue.newMissing(),
+                CompositeValue.fromItems(new U8Value(3), new BytesValue(Buffer.from("abba", "hex"))),
+            ],
+            "0100000064@@03@abba"
+        );
 
-    serializeThenDeserialize(
-      ["MultiArg<List<u16>>", "VarArgs<bytes>"],
-      [
-        CompositeValue.fromItems(List.fromItems([new U16Value(8), new U16Value(9)])),
-        VariadicValue.fromItems(
-          new BytesValue(Buffer.from("abba", "hex")),
-          new BytesValue(Buffer.from("abba", "hex")),
-          new BytesValue(Buffer.from("abba", "hex"))
-        ),
-      ],
-      "00080009@abba@abba@abba"
-    );
+        serializeThenDeserialize(
+            ["MultiArg<List<u16>>", "VarArgs<bytes>"],
+            [
+                CompositeValue.fromItems(List.fromItems([new U16Value(8), new U16Value(9)])),
+                VariadicValue.fromItems(
+                    new BytesValue(Buffer.from("abba", "hex")),
+                    new BytesValue(Buffer.from("abba", "hex")),
+                    new BytesValue(Buffer.from("abba", "hex"))
+                ),
+            ],
+            "00080009@abba@abba@abba"
+        );
 
-    // TODO: In a future PR, improve the types expression parser and enable this test, which currently fails.
+        // TODO: In a future PR, improve the types expression parser and enable this test, which currently fails.
 
-    // serializeThenDeserialize(
-    //     ["MultiArg<Option<u8>, List<u16>>", "VarArgs<bytes>"],
-    //     [
-    //         CompositeValue.fromItems(providedOption(new U8Value(7)), List.fromItems([new U16Value(8), new U16Value(9)])),
-    //         VariadicValue.fromItems(new BytesValue(Buffer.from("abba", "hex")), new BytesValue(Buffer.from("abba", "hex")), new BytesValue(Buffer.from("abba", "hex")))
-    //     ],
-    //     "0107@0000000200080009@abba@abba@abba"
-    // );
-  });
+        // serializeThenDeserialize(
+        //     ["MultiArg<Option<u8>, List<u16>>", "VarArgs<bytes>"],
+        //     [
+        //         CompositeValue.fromItems(providedOption(new U8Value(7)), List.fromItems([new U16Value(8), new U16Value(9)])),
+        //         VariadicValue.fromItems(new BytesValue(Buffer.from("abba", "hex")), new BytesValue(Buffer.from("abba", "hex")), new BytesValue(Buffer.from("abba", "hex")))
+        //     ],
+        //     "0107@0000000200080009@abba@abba@abba"
+        // );
+    });
 
-  it("should serialize <valuesToString> then back <stringToValues>: tuples", async () => {
-    serializeThenDeserialize(
-      ["tuple2<i32, i16>"],
-      [Tuple.fromItems([new I32Value(100), new I16Value(10)])],
-      "00000064000a"
-    );
-  });
+    it("should serialize <valuesToString> then back <stringToValues>: tuples", async () => {
+        serializeThenDeserialize(
+            ["tuple2<i32, i16>"],
+            [Tuple.fromItems([new I32Value(100), new I16Value(10)])],
+            "00000064000a"
+        );
+    });
 
-  function serializeThenDeserialize(typeExpressions: string[], values: TypedValue[], joinedString: string) {
-    let types = typeExpressions
-      .map((expression) => typeParser.parse(expression))
-      .map((type) => typeMapper.mapType(type));
-    let endpointDefinitions = types.map((type) => new EndpointParameterDefinition("foo", "bar", type));
+    function serializeThenDeserialize(typeExpressions: string[], values: TypedValue[], expectedJoinedString: string) {
+        let types = typeExpressions
+            .map((expression) => typeParser.parse(expression))
+            .map((type) => typeMapper.mapType(type));
+        let endpointDefinitions = types.map((type) => new EndpointParameterDefinition("foo", "bar", type));
 
-    // values => joined string
-    let actualJoinedString = serializer.valuesToString(values);
-    assert.equal(actualJoinedString, joinedString);
+        // values => joined string
+        let { argumentsString: actualJoinedString } = serializer.valuesToString(values);
+        assert.equal(actualJoinedString, expectedJoinedString);
 
-    // joined string => values
-    let decodedValues = serializer.stringToValues(actualJoinedString, endpointDefinitions);
+        // joined string => values
+        let decodedValues = serializer.stringToValues(actualJoinedString, endpointDefinitions);
 
-    // Now let's check for equality
-    assert.lengthOf(decodedValues, values.length);
+        // Now let's check for equality
+        assert.lengthOf(decodedValues, values.length);
 
-    for (let i = 0; i < values.length; i++) {
-      let value = values[i];
-      let decoded = decodedValues[i];
+        for (let i = 0; i < values.length; i++) {
+            let value = values[i];
+            let decoded = decodedValues[i];
 
-      assert.deepEqual(decoded.valueOf(), value.valueOf(), `index = ${i}`);
+            assert.deepEqual(decoded.valueOf(), value.valueOf(), `index = ${i}`);
+        }
     }
-  }
 });

--- a/src/smartcontracts/argSerializer.ts
+++ b/src/smartcontracts/argSerializer.ts
@@ -36,7 +36,7 @@ export class ArgSerializer {
         // TODO: Refactor, split (function is quite complex).
 
         buffers = buffers || [];
-        
+
         let values: TypedValue[] = [];
         let bufferIndex = 0;
         let numBuffers = buffers.length;
@@ -99,10 +99,11 @@ export class ArgSerializer {
     /**
      * Serializes a set of typed values into an arguments string (e.g. aa@bb@@cc).
      */
-    valuesToString(values: TypedValue[]): string {
+    valuesToString(values: TypedValue[]): { argumentsString: string, count: number } {
         let strings = this.valuesToStrings(values);
-        let joinedString = strings.join(ArgumentsSeparator);
-        return joinedString;
+        let argumentsString = strings.join(ArgumentsSeparator);
+        let count = strings.length;
+        return { argumentsString, count };
     }
 
     /**
@@ -130,7 +131,7 @@ export class ArgSerializer {
         // This is a recursive function. It appends to the "buffers" variable.
         function handleValue(value: TypedValue): void {
             // TODO: Use matchers.
-            
+
             if (value instanceof OptionalValue) {
                 if (value.isSet()) {
                     handleValue(value.getTypedValue());

--- a/src/smartcontracts/argumentErrorContext.ts
+++ b/src/smartcontracts/argumentErrorContext.ts
@@ -24,10 +24,17 @@ export class ArgumentErrorContext {
         this.throwError(`Unhandled type (function: ${functionName}, type: ${type})`);
     }
 
-    guardSameLength(native: any[], valueTypes: Type[]) {
+    guardSameLength<T>(native: any[], valueTypes: T[]) {
         native = native || [];
         if (native.length != valueTypes.length) {
             this.throwError(`Incorrect composite type length: have ${native.length}, expected ${valueTypes.length} (argument: ${native})`);
+        }
+    }
+
+    guardHasField(native: any, fieldName: string) {
+        native = native || {};
+        if (!(fieldName in native)) {
+            this.throwError(`Struct argument does not contain a field named "${fieldName}" (argument: ${JSON.stringify(native)})`);
         }
     }
 }

--- a/src/smartcontracts/nativeSerializer.ts
+++ b/src/smartcontracts/nativeSerializer.ts
@@ -1,9 +1,10 @@
 import BigNumber from "bignumber.js";
-import { AddressType, AddressValue, BigIntType, BigIntValue, BigUIntType, BigUIntValue, BooleanType, BooleanValue, BytesType, BytesValue, Code, CompositeType, CompositeValue, EndpointDefinition, EndpointParameterDefinition, I16Type, I16Value, I32Type, I32Value, I64Type, I64Value, I8Type, I8Value, List, ListType, NumericalType, OptionalType, OptionalValue, OptionType, OptionValue, PrimitiveType, TokenIdentifierType, TokenIdentifierValue, Type, TypedValue, U16Type, U16Value, U32Type, U32Value, U64Type, U64Value, U8Type, U8Value, VariadicType, VariadicValue } from ".";
+import { AddressType, AddressValue, BigIntType, BigIntValue, BigUIntType, BigUIntValue, BooleanType, BooleanValue, BytesType, BytesValue, Code, CompositeType, CompositeValue, EndpointDefinition, EndpointParameterDefinition, I16Type, I16Value, I32Type, I32Value, I64Type, I64Value, I8Type, I8Value, List, ListType, NumericalType, OptionalType, OptionalValue, OptionType, OptionValue, PrimitiveType, TokenIdentifierType, TokenIdentifierValue, TupleType, Type, TypedValue, U16Type, U16Value, U32Type, U32Value, U64Type, U64Value, U8Type, U8Value, VariadicType, VariadicValue } from ".";
 import { ErrInvalidArgument, Address, BalanceBuilder } from "..";
 import { TestWallet } from "../testutils";
 import { ArgumentErrorContext } from "./argumentErrorContext";
 import { SmartContract } from "./smartContract";
+import { Struct, StructField, StructType, Tuple } from "./typesystem";
 import { ContractWrapper } from "./wrapper/contractWrapper";
 
 export namespace NativeTypes {
@@ -45,9 +46,7 @@ export namespace NativeSerializer {
         if (variadic) {
             let lastArgIndex = parameters.length - 1;
             let lastArg = args.slice(lastArgIndex);
-            if (lastArg.length > 0) {
-                args[lastArgIndex] = lastArg;
-            }
+            args[lastArgIndex] = lastArg;
         }
         return args;
     }
@@ -87,6 +86,12 @@ export namespace NativeSerializer {
         }
         if (type instanceof CompositeType) {
             return toCompositeValue(native, type, errorContext);
+        }
+        if (type instanceof TupleType) {
+            return toTupleValue(native, type, errorContext);
+        }
+        if (type instanceof StructType) {
+            return toStructValue(native, type, errorContext);
         }
         if (type instanceof ListType) {
             return toListValue(native, type, errorContext);
@@ -147,6 +152,29 @@ export namespace NativeSerializer {
         return new CompositeValue(type, typedValues);
     }
 
+    function toTupleValue(native: any, type: TupleType, errorContext: ArgumentErrorContext): TypedValue {
+        let typedValues = [];
+        const fields = type.fields;
+        errorContext.guardSameLength(native, fields);
+        for (let i in fields) {
+            typedValues.push(convertToTypedValue(native[i], fields[i].type, errorContext));
+        }
+        return Tuple.fromItems(typedValues);
+    }
+
+    function toStructValue(native: any, type: StructType, errorContext: ArgumentErrorContext): TypedValue {
+        let structFieldValues = [];
+        const fields = type.fields;
+        for (let i in fields) {
+            const fieldName = fields[i].name;
+            errorContext.guardHasField(native, fieldName);
+            const fieldNativeValue = native[fieldName];
+            const fieldTypedValue = convertToTypedValue(fieldNativeValue, fields[i].type, errorContext);
+            structFieldValues.push(new StructField(fieldTypedValue, fieldName));
+        }
+        return new Struct(type, structFieldValues);
+    }
+
     function toPrimitive(native: any, type: Type, errorContext: ArgumentErrorContext): TypedValue {
         if (type instanceof NumericalType) {
             let number = new BigNumber(native);
@@ -168,6 +196,9 @@ export namespace NativeSerializer {
     }
 
     function convertNativeToBytesValue(native: NativeTypes.NativeBytes, errorContext: ArgumentErrorContext) {
+        if (native === undefined) {
+            errorContext.convertError(native, "BytesValue");
+        }
         if (native instanceof Code) {
             return BytesValue.fromHex(native.toString());
         }
@@ -184,6 +215,9 @@ export namespace NativeSerializer {
     }
 
     function convertNativeToBuffer(native: NativeTypes.NativeBuffer, errorContext: ArgumentErrorContext): Buffer {
+        if (native === undefined) {
+            errorContext.convertError(native, "Buffer");
+        }
         if (native instanceof Buffer) {
             return native;
         }

--- a/src/smartcontracts/transactionPayloadBuilders.ts
+++ b/src/smartcontracts/transactionPayloadBuilders.ts
@@ -164,10 +164,9 @@ export class ContractCallPayloadBuilder {
 }
 
 function appendArgumentsToString(to: string, values: TypedValue[]) {
-    if (values.length == 0) {
+    let { argumentsString, count } = new ArgSerializer().valuesToString(values);
+    if (count == 0) {
         return to;
     }
-
-    let argumentsString = new ArgSerializer().valuesToString(values);
     return `${to}@${argumentsString}`;
 }

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -147,7 +147,7 @@ export class TypeCardinality {
     }
 
     isComposite(): boolean {
-        return !this.isSingular();
+        return this.upperBound != 1;
     }
 
     isFixed(): boolean {


### PR DESCRIPTION
- Add native serializer support for `Struct` and `Tuple` types
- Fix bug in `isComposite` - it should return false for `Optional` types
- Fix bug for `appendArgumentsToString` where a call which has a `VarArgs` argument would be formatted as `myFunction@` instead of `myFunction` (an extra `@` at the end) even if no arguments would have been provided. For this the `valuesToString` now returns an additional `count` which represents the actual number of arguments in the serialized argument string. Updated the unit test.
- Add guards for two convert to native functions which contain the check `if (((<BalanceBuilder>native).getTokenIdentifier)) {`. This check fails if the `native` value is `undefined` and as such did not display a proper error message using the `errorContext`