### PR TITLE
prevent multiple instances of extension provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
-## [8.0.0]
+
 - [ExtensionProvider] https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/66
 
     - ### Breaking changes:

--- a/src/dapp/extensionProvider.ts
+++ b/src/dapp/extensionProvider.ts
@@ -7,6 +7,7 @@ declare global {
     elrondWallet: { extensionId: string };
   }
 }
+
 interface IExtensionAccount {
   address: string;
   name?: string;


### PR DESCRIPTION
Prevent multiple instances of extension provider in order to keep the state of login information stored in provider properties 