### PR TITLE
Set offset when reading integers from buffer

### DIFF
--- a/src/smartcontracts/codec/boolean.ts
+++ b/src/smartcontracts/codec/boolean.ts
@@ -12,7 +12,7 @@ export class BooleanBinaryCodec {
     decodeNested(buffer: Buffer): [BooleanValue, number] {
         // We don't check the size of the buffer, we just read the first byte.
 
-        let byte = buffer.readUInt8();
+        let byte = buffer.readUInt8(0);
         return [new BooleanValue(byte == BooleanBinaryCodec.TRUE), 1];
     }
 

--- a/src/smartcontracts/codec/bytes.ts
+++ b/src/smartcontracts/codec/bytes.ts
@@ -7,7 +7,7 @@ import { SizeOfU32 } from "./constants";
  */
 export class BytesBinaryCodec {
     decodeNested(buffer: Buffer): [BytesValue, number] {
-        let length = buffer.readUInt32BE();
+        let length = buffer.readUInt32BE(0);
         let payload = buffer.slice(SizeOfU32, SizeOfU32 + length);
         let result = new BytesValue(payload);
         return [result, SizeOfU32 + length];

--- a/src/smartcontracts/codec/list.ts
+++ b/src/smartcontracts/codec/list.ts
@@ -16,7 +16,7 @@ export class ListBinaryCodec {
     decodeNested(buffer: Buffer, type: Type): [List, number] {
         let typeParameter = type.getFirstTypeParameter();
         let result: TypedValue[] = [];
-        let numItems = buffer.readUInt32BE();
+        let numItems = buffer.readUInt32BE(0);
         this.binaryCodec.constraints.checkListLength(numItems);
 
         let originalBuffer = buffer;

--- a/src/smartcontracts/codec/numerical.ts
+++ b/src/smartcontracts/codec/numerical.ts
@@ -16,7 +16,7 @@ export class NumericalBinaryCodec {
             // Size of type is not known: arbitrary-size big integer.
             // Therefore, we must read the length from the header.
             offset = SizeOfU32;
-            length = buffer.readUInt32BE();
+            length = buffer.readUInt32BE(0);
         }
 
         let payload = buffer.slice(offset, offset + length);


### PR DESCRIPTION
Older version of Buffer (4.9.2) used in webpack 4 throws error when reading integers without specifying offset.