### PR TITLE
Handle heterogeneous enums with fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - [Fix smart contract results to align to the new API field namings]
     - Breaking changes:
         - `smartContractResults` property in `TransactionOnNetwork` was renamed to `results` as in the new API,
-        affecting `fromHttpResponse` method 
+        affecting `fromHttpResponse` method
+        - `ErrStructTyping` has been removed
+        - `EnumValue.valueOf()` does not return a string (the name of the variant) anymore. It returns a JS object such as `{"name": "name of variant", "fields": { ... }}`
+        - `StructFieldDefinition` has been replaced by `FieldDefinition`, while `StructField` has been replaced by `Field`.
 
  - [Fix ExtensionProvider sign/send transaction response #72](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/72)
     - Provider's send/sign transaction methonds responded with plainObject transactions instead of Transaction
@@ -22,6 +25,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - [Handle extension errors #87](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/87)
     - Handle erros when sign/send transactions fails on extension side
+- [Handle heterogeneous enums with fields](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/98)
 
 ## [8.0.0]
 - [ExtensionProvider] https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/66

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -400,15 +400,6 @@ export class ErrTypingSystem extends Err {
 }
 
 /**
- * Signals a generic struct typing error.
- */
-export class ErrStructTyping extends Err {
-    public constructor(reason: string) {
-        super(`Incorrect struct typing: ${reason}`);
-    }
-}
-
-/**
  * Signals a generic codec (encode / decode) error.
  */
 export class ErrCodec extends Err {

--- a/src/smartcontracts/codec/binary.spec.ts
+++ b/src/smartcontracts/codec/binary.spec.ts
@@ -1,11 +1,12 @@
 import { assert } from "chai";
 import { BinaryCodec, BinaryCodecConstraints } from "./binary";
-import { AddressType, AddressValue, BigIntType, BigUIntType, BigUIntValue, BooleanType, BooleanValue, I16Type, I32Type, I64Type, I8Type, NumericalType, NumericalValue, Struct, StructField, StructFieldDefinition, StructType, TypedValue, U16Type, U32Type, U32Value, U64Type, U64Value, U8Type, U8Value, List, ListType, EnumType, EnumVariantDefinition, EnumValue } from "../typesystem";
+import { AddressType, AddressValue, BigIntType, BigUIntType, BigUIntValue, BooleanType, BooleanValue, I16Type, I32Type, I64Type, I8Type, NumericalType, NumericalValue, Struct, Field, StructType, TypedValue, U16Type, U32Type, U32Value, U64Type, U64Value, U8Type, U8Value, List, ListType, EnumType, EnumVariantDefinition, EnumValue } from "../typesystem";
 import { discardSuperfluousBytesInTwosComplement, discardSuperfluousZeroBytes, isMsbOne } from "./utils";
 import { Address } from "../../address";
 import { Balance } from "../../balance";
 import { BytesType, BytesValue } from "../typesystem/bytes";
 import BigNumber from "bignumber.js";
+import { FieldDefinition } from "../typesystem/fields";
 
 describe("test binary codec (basic)", () => {
     let codec = new BinaryCodec();
@@ -143,26 +144,26 @@ describe("test binary codec (advanced)", () => {
         let fooType = new StructType(
             "Foo",
             [
-                new StructFieldDefinition("ticket_price", "", new BigUIntType()),
-                new StructFieldDefinition("tickets_left", "", new U32Type()),
-                new StructFieldDefinition("deadline", "", new U64Type()),
-                new StructFieldDefinition("max_entries_per_user", "", new U32Type()),
-                new StructFieldDefinition("prize_distribution", "", new BytesType()),
-                new StructFieldDefinition("whitelist", "", new ListType(new AddressType())),
-                new StructFieldDefinition("current_ticket_number", "", new U32Type()),
-                new StructFieldDefinition("prize_pool", "", new BigUIntType())
+                new FieldDefinition("ticket_price", "", new BigUIntType()),
+                new FieldDefinition("tickets_left", "", new U32Type()),
+                new FieldDefinition("deadline", "", new U64Type()),
+                new FieldDefinition("max_entries_per_user", "", new U32Type()),
+                new FieldDefinition("prize_distribution", "", new BytesType()),
+                new FieldDefinition("whitelist", "", new ListType(new AddressType())),
+                new FieldDefinition("current_ticket_number", "", new U32Type()),
+                new FieldDefinition("prize_pool", "", new BigUIntType())
             ]
         );
 
         let fooStruct = new Struct(fooType, [
-            new StructField(new BigUIntValue(Balance.egld(10).valueOf()), "ticket_price"),
-            new StructField(new U32Value(0), "tickets_left"),
-            new StructField(new U64Value(new BigNumber("0x000000005fc2b9db")), "deadline"),
-            new StructField(new U32Value(0xffffffff), "max_entries_per_user"),
-            new StructField(new BytesValue(Buffer.from([0x64])), "prize_distribution"),
-            new StructField(new List(new ListType(new AddressType()), []), "whitelist"),
-            new StructField(new U32Value(9472), "current_ticket_number"),
-            new StructField(new BigUIntValue(new BigNumber("94720000000000000000000")), "prize_pool")
+            new Field(new BigUIntValue(Balance.egld(10).valueOf()), "ticket_price"),
+            new Field(new U32Value(0), "tickets_left"),
+            new Field(new U64Value(new BigNumber("0x000000005fc2b9db")), "deadline"),
+            new Field(new U32Value(0xffffffff), "max_entries_per_user"),
+            new Field(new BytesValue(Buffer.from([0x64])), "prize_distribution"),
+            new Field(new List(new ListType(new AddressType()), []), "whitelist"),
+            new Field(new U32Value(9472), "current_ticket_number"),
+            new Field(new BigUIntValue(new BigNumber("94720000000000000000000")), "prize_pool")
         ]);
 
         let encodedExpected = serialized("[00000008|8ac7230489e80000] [00000000] [000000005fc2b9db] [ffffffff] [00000001|64] [00000000] [00002500] [0000000a|140ec80fa7ee88000000]");

--- a/src/smartcontracts/codec/binary.spec.ts
+++ b/src/smartcontracts/codec/binary.spec.ts
@@ -217,6 +217,66 @@ describe("test binary codec (advanced)", () => {
         [decoded] = codec.decodeNested(Buffer.from([0xFF]), enumType);
         assert.deepEqual(decoded, blue);
     });
+
+    it("should encode / decode (heterogeneous) enums with fields", async () => {
+        let codec = new BinaryCodec();
+        let typeOfListOfStrings = new ListType(new BytesType());
+
+        let orangeVariant = new EnumVariantDefinition("Orange", 0, [
+            new FieldDefinition("0", "red component", new U8Type()),
+            new FieldDefinition("1", "green component", new U8Type()),
+            new FieldDefinition("2", "blue component", new U8Type()),
+            new FieldDefinition("3", "hex code", new BytesType()),
+            new FieldDefinition("4", "fruits", typeOfListOfStrings)
+        ]);
+
+        let blueVariant = new EnumVariantDefinition("Blue", 1, [
+            new FieldDefinition("0", "hex code", new BytesType()),
+            new FieldDefinition("1", "fruits", typeOfListOfStrings)
+        ]);
+
+        let enumType = new EnumType("Colour", [
+           orangeVariant,
+           blueVariant 
+        ]);
+
+        let orange = new EnumValue(enumType, orangeVariant, [
+            new Field(new U8Value(255), "0"),
+            new Field(new U8Value(165), "1"),
+            new Field(new U8Value(0), "2"),
+            new Field(BytesValue.fromUTF8("#FFA500"), "3"),
+            new Field(new List(typeOfListOfStrings, [BytesValue.fromUTF8("orange"), BytesValue.fromUTF8("persimmon")]), "4")
+        ]);
+
+        let blue = new EnumValue(enumType, blueVariant, [
+            new Field(BytesValue.fromUTF8("#0000FF"), "0"),
+            new Field(new List(typeOfListOfStrings, [BytesValue.fromUTF8("blueberry"), BytesValue.fromUTF8("plum")]), "1")
+        ]);
+
+        // Orange
+        // [[discriminant = 0]] [R] [G] [B] [bytes for hex code] [list of 2 elements (fruits)]
+        let orangeEncodedNested = serialized("[[00]] [ff] [a5] [00] [00000007 | 23464641353030] [00000002 | [00000006|6f72616e6765] [00000009|70657273696d6d6f6e]]");
+        let orangeEncodedTopLevel = orangeEncodedNested;
+        assert.deepEqual(codec.encodeNested(orange), orangeEncodedNested);
+        assert.deepEqual(codec.encodeTopLevel(orange), orangeEncodedTopLevel);
+
+        let [decoded] = codec.decodeNested(orangeEncodedNested, enumType);
+        assert.deepEqual(decoded, orange);
+        decoded = codec.decodeTopLevel(orangeEncodedTopLevel, enumType);
+        assert.deepEqual(decoded, orange);
+
+        // Blue
+        // [[discriminant = 01]] [bytes for hex code] [list of 2 elements (fruits)]
+        let blueEncodedNested = serialized("[[01]] [00000007 | 23303030304646] [ 00000002 | [00000009|626c75656265727279] [00000004|706c756d]]");
+        let blueEncodedTopLevel = blueEncodedNested;
+        assert.deepEqual(codec.encodeNested(blue), blueEncodedNested);
+        assert.deepEqual(codec.encodeTopLevel(blue), blueEncodedTopLevel);
+
+        [decoded] = codec.decodeNested(blueEncodedNested, enumType);
+        assert.deepEqual(decoded, blue);
+        decoded = codec.decodeTopLevel(blueEncodedTopLevel, enumType);
+        assert.deepEqual(decoded, blue);
+    });
 });
 
 function serialized(prettyHex: string): Buffer {

--- a/src/smartcontracts/codec/enum.ts
+++ b/src/smartcontracts/codec/enum.ts
@@ -12,6 +12,7 @@ export class EnumBinaryCodec {
     }
 
     decodeTopLevel(buffer: Buffer, type: EnumType): EnumValue {
+        // This handles enums without fields, with discriminant = 0, as well.
         let [enumValue] = this.decodeNested(buffer, type);
         return enumValue;
     }

--- a/src/smartcontracts/codec/enum.ts
+++ b/src/smartcontracts/codec/enum.ts
@@ -1,29 +1,49 @@
-import { EnumType, U8Type, U8Value, EnumValue } from "../typesystem";
+import { EnumType, U8Type, U8Value, EnumValue, Field } from "../typesystem";
 import { BinaryCodec } from "./binary";
+import { FieldsBinaryCodec } from "./fields";
 
 export class EnumBinaryCodec {
     private readonly binaryCodec: BinaryCodec;
+    private readonly fieldsCodec: FieldsBinaryCodec;
 
     constructor(binaryCodec: BinaryCodec) {
         this.binaryCodec = binaryCodec;
+        this.fieldsCodec = new FieldsBinaryCodec(binaryCodec);
     }
 
     decodeTopLevel(buffer: Buffer, type: EnumType): EnumValue {
-        let [enumValue, _] = this.decodeNested(buffer, type);
+        let [enumValue] = this.decodeNested(buffer, type);
         return enumValue;
     }
 
     decodeNested(buffer: Buffer, type: EnumType): [EnumValue, number] {
-        // Read as plain byte
+        let [discriminant, lengthOfDiscriminant] = this.readDiscriminant(buffer);
+        buffer = buffer.slice(lengthOfDiscriminant);
+
+        let variant = type.getVariantByDiscriminant(discriminant);
+        let fieldDefinitions = variant.getFieldsDefinitions();
+        
+        let [fields, lengthOfFields]: [Field[], number] = this.fieldsCodec.decodeNested(buffer, fieldDefinitions);
+        let enumValue = new EnumValue(type, variant, fields);
+
+        return [enumValue, lengthOfDiscriminant + lengthOfFields];
+    }
+
+    private readDiscriminant(buffer: Buffer): [discriminant: number, length: number] {
         let [value, length] = this.binaryCodec.decodeNested(buffer, new U8Type());
-        let enumValue = EnumValue.fromDiscriminant(type, Number(value.valueOf()));
-        return [enumValue, length];
+        let discriminant = value.valueOf();
+        
+        return [discriminant, length];
     }
 
     encodeNested(enumValue: EnumValue): Buffer {
-        let value = new U8Value(enumValue.discriminant);
-        let buffer = this.binaryCodec.encodeNested(value);
-        return buffer;
+        let discriminant = new U8Value(enumValue.discriminant);
+        let discriminantBuffer = this.binaryCodec.encodeNested(discriminant);
+
+        let fields = enumValue.getFields();
+        let fieldsBuffer = this.fieldsCodec.encodeNested(fields);
+
+        return Buffer.concat([discriminantBuffer, fieldsBuffer]);
     }
 
     encodeTopLevel(enumValue: EnumValue): Buffer {

--- a/src/smartcontracts/codec/enum.ts
+++ b/src/smartcontracts/codec/enum.ts
@@ -47,8 +47,13 @@ export class EnumBinaryCodec {
     }
 
     encodeTopLevel(enumValue: EnumValue): Buffer {
-        let value = new U8Value(enumValue.discriminant);
-        let buffer = this.binaryCodec.encodeTopLevel(value);
-        return buffer;
+        let fields = enumValue.getFields();
+        let hasFields = fields.length > 0;
+        let fieldsBuffer = this.fieldsCodec.encodeNested(fields);
+        
+        let discriminant = new U8Value(enumValue.discriminant);
+        let discriminantBuffer = hasFields ? this.binaryCodec.encodeNested(discriminant) : this.binaryCodec.encodeTopLevel(discriminant);
+
+        return Buffer.concat([discriminantBuffer, fieldsBuffer]);
     }
 }

--- a/src/smartcontracts/codec/fields.ts
+++ b/src/smartcontracts/codec/fields.ts
@@ -1,0 +1,37 @@
+import { Field, FieldDefinition } from "../typesystem";
+import { BinaryCodec } from "./binary";
+
+export class FieldsBinaryCodec {
+    private readonly binaryCodec: BinaryCodec;
+
+    constructor(binaryCodec: BinaryCodec) {
+        this.binaryCodec = binaryCodec;
+    }
+
+    decodeNested(buffer: Buffer, fieldDefinitions: FieldDefinition[]): [Field[], number] {
+        let fields: Field[] = [];
+        let totalLength = 0;
+
+        for (const fieldDefinition of fieldDefinitions) {
+            let [decoded, decodedLength] = this.binaryCodec.decodeNested(buffer, fieldDefinition.type);
+            buffer = buffer.slice(decodedLength);
+            totalLength += decodedLength;
+
+            let field = new Field(decoded, fieldDefinition.name);
+            fields.push(field);
+        }
+        
+        return [fields, totalLength];
+    }
+
+    encodeNested(fields: ReadonlyArray<Field>): Buffer {
+        let buffers: Buffer[] = [];
+        
+        for (const field of fields) {
+            let fieldBuffer = this.binaryCodec.encodeNested(field.value);
+            buffers.push(fieldBuffer);
+        }
+
+        return Buffer.concat(buffers);
+    }
+}

--- a/src/smartcontracts/codec/nothing.ts
+++ b/src/smartcontracts/codec/nothing.ts
@@ -1,0 +1,19 @@
+import { NothingValue } from "../typesystem";
+
+export class NothingCodec {
+    decodeNested(): [NothingValue, number] {
+        return [new NothingValue(), 0];
+    }
+
+    decodeTopLevel(): NothingValue {
+        return new NothingValue();
+    }
+
+    encodeNested(): Buffer {
+        return Buffer.from([]);
+    }
+
+    encodeTopLevel(): Buffer {
+        return Buffer.from([]);
+    }
+}

--- a/src/smartcontracts/codec/primitive.ts
+++ b/src/smartcontracts/codec/primitive.ts
@@ -18,6 +18,7 @@ import { H256Value } from "../typesystem/h256";
 import { BytesBinaryCodec } from "./bytes";
 import { TokenIdentifierCodec } from "./tokenIdentifier";
 import { TokenIdentifierValue } from "../typesystem/tokenIdentifier";
+import { NothingCodec } from "./nothing";
 
 export class PrimitiveBinaryCodec {
     private readonly binaryCodec: BinaryCodec;
@@ -28,6 +29,7 @@ export class PrimitiveBinaryCodec {
     private readonly h256Codec: H256BinaryCodec;
     private readonly bytesCodec: BytesBinaryCodec;
     private readonly tokenIdentifierCodec: TokenIdentifierCodec;
+    private readonly nothingCodec: NothingCodec;
 
     constructor(binaryCodec: BinaryCodec) {
         this.binaryCodec = binaryCodec;
@@ -38,6 +40,7 @@ export class PrimitiveBinaryCodec {
         this.h256Codec = new H256BinaryCodec();
         this.bytesCodec = new BytesBinaryCodec();
         this.tokenIdentifierCodec = new TokenIdentifierCodec();
+        this.nothingCodec = new NothingCodec();
     }
 
     decodeNested(buffer: Buffer, type: PrimitiveType): [PrimitiveValue, number] {
@@ -48,6 +51,7 @@ export class PrimitiveBinaryCodec {
             onBytes: () => this.bytesCodec.decodeNested(buffer),
             onH256: () => this.h256Codec.decodeNested(buffer),
             onTokenIndetifier: () => this.tokenIdentifierCodec.decodeNested(buffer),
+            onNothing: () => this.nothingCodec.decodeNested()
         });
     }
 
@@ -59,6 +63,7 @@ export class PrimitiveBinaryCodec {
             onBytes: () => this.bytesCodec.decodeTopLevel(buffer),
             onH256: () => this.h256Codec.decodeTopLevel(buffer),
             onTokenIndetifier: () => this.tokenIdentifierCodec.decodeTopLevel(buffer),
+            onNothing: () => this.nothingCodec.decodeTopLevel()
         });
     }
 
@@ -70,6 +75,7 @@ export class PrimitiveBinaryCodec {
             onBytes: () => this.bytesCodec.encodeNested(<BytesValue>value),
             onH256: () => this.h256Codec.encodeNested(<H256Value>value),
             onTypeIdentifier: () => this.tokenIdentifierCodec.encodeNested(<TokenIdentifierValue>value),
+            onNothing: () => this.nothingCodec.encodeNested()
         });
     }
 
@@ -81,6 +87,7 @@ export class PrimitiveBinaryCodec {
             onBytes: () => this.bytesCodec.encodeTopLevel(<BytesValue>value),
             onH256: () => this.h256Codec.encodeTopLevel(<H256Value>value),
             onTypeIdentifier: () => this.tokenIdentifierCodec.encodeTopLevel(<TokenIdentifierValue>value),
+            onNothing: () => this.nothingCodec.encodeTopLevel()
         });
     }
 }

--- a/src/smartcontracts/codec/struct.ts
+++ b/src/smartcontracts/codec/struct.ts
@@ -1,47 +1,29 @@
 import { StructType, Struct, Field } from "../typesystem";
 import { BinaryCodec } from "./binary";
+import { FieldsBinaryCodec } from "./fields";
 
 export class StructBinaryCodec {
-    private readonly binaryCodec: BinaryCodec;
+    private readonly fieldsCodec: FieldsBinaryCodec;
 
     constructor(binaryCodec: BinaryCodec) {
-        this.binaryCodec = binaryCodec;
+        this.fieldsCodec = new FieldsBinaryCodec(binaryCodec);
     }
 
     decodeTopLevel(buffer: Buffer, type: StructType): Struct {
-        let [decoded, length] = this.decodeNested(buffer, type);
+        let [decoded] = this.decodeNested(buffer, type);
         return decoded;
     }
 
     decodeNested(buffer: Buffer, type: StructType): [Struct, number] {
-        let originalBuffer = buffer;
-        let offset = 0;
-
-        let fieldDefinitions = type.fields;
-        let fields: Field[] = [];
-
-        for (const fieldDefinition of fieldDefinitions) {
-            let [decoded, decodedLength] = this.binaryCodec.decodeNested(buffer, fieldDefinition.type);
-            let field = new Field(decoded, fieldDefinition.name);
-            fields.push(field);
-            offset += decodedLength;
-            buffer = originalBuffer.slice(offset);
-        }
-        
+        let fieldDefinitions = type.getFieldsDefinitions();
+        let [fields, offset]: [Field[], number] = this.fieldsCodec.decodeNested(buffer, fieldDefinitions);
         let struct = new Struct(type, fields);
         return [struct, offset];
     }
 
     encodeNested(struct: Struct): Buffer {
-        let buffers: Buffer[] = [];
         let fields = struct.getFields();
-        
-        for (const field of fields) {
-            let fieldBuffer = this.binaryCodec.encodeNested(field.value);
-            buffers.push(fieldBuffer);
-        }
-
-        let buffer = Buffer.concat(buffers);
+        let buffer = this.fieldsCodec.encodeNested(fields);
         return buffer;
     }
 

--- a/src/smartcontracts/codec/struct.ts
+++ b/src/smartcontracts/codec/struct.ts
@@ -1,4 +1,4 @@
-import { StructType, Struct, StructField } from "../typesystem";
+import { StructType, Struct, Field } from "../typesystem";
 import { BinaryCodec } from "./binary";
 
 export class StructBinaryCodec {
@@ -18,11 +18,11 @@ export class StructBinaryCodec {
         let offset = 0;
 
         let fieldDefinitions = type.fields;
-        let fields: StructField[] = [];
+        let fields: Field[] = [];
 
         for (const fieldDefinition of fieldDefinitions) {
             let [decoded, decodedLength] = this.binaryCodec.decodeNested(buffer, fieldDefinition.type);
-            let field = new StructField(decoded, fieldDefinition.name);
+            let field = new Field(decoded, fieldDefinition.name);
             fields.push(field);
             offset += decodedLength;
             buffer = originalBuffer.slice(offset);

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -2,7 +2,15 @@ import { StrictChecker } from "./strictChecker";
 import { DefaultInteractionRunner } from "./defaultRunner";
 import { SmartContract } from "./smartContract";
 import { BigUIntValue, OptionValue, U32Value } from "./typesystem";
-import { AddImmediateResult, loadAbiRegistry, loadTestWallets, MarkNotarized, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../testutils";
+import {
+    AddImmediateResult,
+    loadAbiRegistry,
+    loadTestWallets,
+    MarkNotarized,
+    MockProvider,
+    setupUnitTestWatcherTimeouts,
+    TestWallet,
+} from "../testutils";
 import { SmartContractAbi } from "./abi";
 import { Address } from "../address";
 import { assert } from "chai";
@@ -17,18 +25,18 @@ import { Balance } from "../balance";
 import BigNumber from "bignumber.js";
 import { BytesValue } from "./typesystem/bytes";
 
-describe("test smart contract interactor", function () {
+describe("test smart contract interactor", function() {
     let dummyAddress = new Address("erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3");
     let checker = new StrictChecker();
     let provider = new MockProvider();
     let alice: TestWallet;
     let runner: DefaultInteractionRunner;
-    before(async function () {
+    before(async function() {
         ({ alice } = await loadTestWallets());
         runner = new DefaultInteractionRunner(checker, alice.signer, provider);
     });
 
-    it("should interact with 'answer'", async function () {
+    it("should interact with 'answer'", async function() {
         setupUnitTestWatcherTimeouts();
 
         let abiRegistry = await loadAbiRegistry(["src/testdata/answer.abi.json"]);
@@ -42,10 +50,15 @@ describe("test smart contract interactor", function () {
         assert.lengthOf(interaction.getArguments(), 0);
         assert.deepEqual(interaction.getGasLimit(), new GasLimit(543210));
 
-        provider.mockQueryResponseOnFunction("getUltimateAnswer", new QueryResponse({ returnData: ["Kg=="], returnCode: ReturnCode.Ok }));
+        provider.mockQueryResponseOnFunction(
+            "getUltimateAnswer",
+            new QueryResponse({ returnData: ["Kg=="], returnCode: ReturnCode.Ok })
+        );
 
         // Query
-        let { values: queryValues, firstValue: queryAnwser, returnCode: queryCode } = await runner.runQuery(interaction);
+        let { values: queryValues, firstValue: queryAnwser, returnCode: queryCode } = await runner.runQuery(
+            interaction
+        );
         assert.lengthOf(queryValues, 1);
         assert.deepEqual(queryAnwser.valueOf(), new BigNumber(42));
         assert.isTrue(queryCode.equals(ReturnCode.Ok));
@@ -54,16 +67,29 @@ describe("test smart contract interactor", function () {
         let transaction = await runner.run(interaction.withNonce(new Nonce(0)));
         assert.equal(transaction.getNonce().valueOf(), 0);
         assert.equal(transaction.getData().toString(), "getUltimateAnswer");
-        assert.equal(transaction.getHash().toString(), "60d0956a8902c1179dce92d91bd9670e31b9a9cd07c1d620edb7754a315b4818");
+        assert.equal(
+            transaction.getHash().toString(),
+            "60d0956a8902c1179dce92d91bd9670e31b9a9cd07c1d620edb7754a315b4818"
+        );
 
         transaction = await runner.run(interaction.withNonce(new Nonce(1)));
         assert.equal(transaction.getNonce().valueOf(), 1);
-        assert.equal(transaction.getHash().toString(), "acd207c38f6c3341b18d8ef331fa07ba49615fa12d7610aad5d8495293049f24");
+        assert.equal(
+            transaction.getHash().toString(),
+            "acd207c38f6c3341b18d8ef331fa07ba49615fa12d7610aad5d8495293049f24"
+        );
 
         // Execute, and wait for execution
-        let [, { values: executionValues, firstValue: executionAnswer, returnCode: executionCode }] = await Promise.all([
-            provider.mockNextTransactionTimeline([new TransactionStatus("executed"), new AddImmediateResult("@6f6b@2b"), new MarkNotarized()]),
-            runner.runAwaitExecution(interaction.withNonce(new Nonce(2)))
+        let [
+            ,
+            { values: executionValues, firstValue: executionAnswer, returnCode: executionCode },
+        ] = await Promise.all([
+            provider.mockNextTransactionTimeline([
+                new TransactionStatus("executed"),
+                new AddImmediateResult("@6f6b@2b"),
+                new MarkNotarized(),
+            ]),
+            runner.runAwaitExecution(interaction.withNonce(new Nonce(2))),
         ]);
 
         assert.lengthOf(executionValues, 1);
@@ -71,7 +97,7 @@ describe("test smart contract interactor", function () {
         assert.isTrue(executionCode.equals(ReturnCode.Ok));
     });
 
-    it("should interact with 'counter'", async function () {
+    it("should interact with 'counter'", async function() {
         setupUnitTestWatcherTimeouts();
 
         let abiRegistry = await loadAbiRegistry(["src/testdata/counter.abi.json"]);
@@ -83,7 +109,10 @@ describe("test smart contract interactor", function () {
         let decrementInteraction = (<Interaction>contract.methods.decrement()).withGasLimit(new GasLimit(987654));
 
         // For "get()", return fake 7
-        provider.mockQueryResponseOnFunction("get", new QueryResponse({ returnData: ["Bw=="], returnCode: ReturnCode.Ok }));
+        provider.mockQueryResponseOnFunction(
+            "get",
+            new QueryResponse({ returnData: ["Bw=="], returnCode: ReturnCode.Ok })
+        );
 
         // Query "get()"
         let { firstValue: counterValue } = await runner.runQuery(getInteraction);
@@ -92,8 +121,12 @@ describe("test smart contract interactor", function () {
 
         // Increment, wait for execution. Return fake 8
         let [, { firstValue: valueAfterIncrement }] = await Promise.all([
-            provider.mockNextTransactionTimeline([new TransactionStatus("executed"), new AddImmediateResult("@6f6b@08"), new MarkNotarized()]),
-            runner.runAwaitExecution(incrementInteraction.withNonce(new Nonce(14)))
+            provider.mockNextTransactionTimeline([
+                new TransactionStatus("executed"),
+                new AddImmediateResult("@6f6b@08"),
+                new MarkNotarized(),
+            ]),
+            runner.runAwaitExecution(incrementInteraction.withNonce(new Nonce(14))),
         ]);
 
         assert.deepEqual(valueAfterIncrement.valueOf(), new BigNumber(8));
@@ -103,66 +136,112 @@ describe("test smart contract interactor", function () {
         await runner.run(decrementInteraction.withNonce(new Nonce(16)));
 
         let [, { firstValue: valueAfterDecrement }] = await Promise.all([
-            provider.mockNextTransactionTimeline([new TransactionStatus("executed"), new AddImmediateResult("@6f6b@05"), new MarkNotarized()]),
-            runner.runAwaitExecution(decrementInteraction.withNonce(new Nonce(17)))
+            provider.mockNextTransactionTimeline([
+                new TransactionStatus("executed"),
+                new AddImmediateResult("@6f6b@05"),
+                new MarkNotarized(),
+            ]),
+            runner.runAwaitExecution(decrementInteraction.withNonce(new Nonce(17))),
         ]);
 
         assert.deepEqual(valueAfterDecrement.valueOf(), new BigNumber(5));
     });
 
-    it("should interact with 'lottery_egld'", async function () {
+    it("should interact with 'lottery_egld'", async function() {
         setupUnitTestWatcherTimeouts();
 
         let abiRegistry = await loadAbiRegistry(["src/testdata/lottery_egld.abi.json"]);
         let abi = new SmartContractAbi(abiRegistry, ["Lottery"]);
         let contract = new SmartContract({ address: dummyAddress, abi: abi });
 
-        let startInteraction = <Interaction>contract.methods.start([
-            BytesValue.fromUTF8("lucky"),
-            new BigUIntValue(Balance.egld(1).valueOf()),
-            OptionValue.newMissing(),
-            OptionValue.newMissing(),
-            OptionValue.newProvided(new U32Value(1)),
-            OptionValue.newMissing(),
-            OptionValue.newMissing(),
-        ]).withGasLimit(new GasLimit(5000000));
+        let startInteraction = <Interaction>(
+            contract.methods
+                .start([
+                    BytesValue.fromUTF8("lucky"),
+                    new BigUIntValue(Balance.egld(1).valueOf()),
+                    OptionValue.newMissing(),
+                    OptionValue.newMissing(),
+                    OptionValue.newProvided(new U32Value(1)),
+                    OptionValue.newMissing(),
+                    OptionValue.newMissing(),
+                ])
+                .withGasLimit(new GasLimit(5000000))
+        );
 
-        let lotteryStatusInteraction = <Interaction>contract.methods.status([
-            BytesValue.fromUTF8("lucky")
-        ]).withGasLimit(new GasLimit(5000000));
+        let lotteryStatusInteraction = <Interaction>(
+            contract.methods.status([BytesValue.fromUTF8("lucky")]).withGasLimit(new GasLimit(5000000))
+        );
 
-        let getLotteryInfoInteraction = <Interaction>contract.methods.lotteryInfo([
-            BytesValue.fromUTF8("lucky")
-        ]).withGasLimit(new GasLimit(5000000));
+        let getLotteryInfoInteraction = <Interaction>(
+            contract.methods.lotteryInfo([BytesValue.fromUTF8("lucky")]).withGasLimit(new GasLimit(5000000))
+        );
 
         // start()
         let [, { returnCode: startReturnCode, values: startReturnvalues }] = await Promise.all([
-            provider.mockNextTransactionTimeline([new TransactionStatus("executed"), new AddImmediateResult("@6f6b"), new MarkNotarized()]),
-            runner.runAwaitExecution(startInteraction.withNonce(new Nonce(14)))
+            provider.mockNextTransactionTimeline([
+                new TransactionStatus("executed"),
+                new AddImmediateResult("@6f6b"),
+                new MarkNotarized(),
+            ]),
+            runner.runAwaitExecution(startInteraction.withNonce(new Nonce(14))),
         ]);
 
-        assert.equal(startInteraction.buildTransaction().getData().toString(), "start@6c75636b79@0de0b6b3a7640000@@@0100000001@@");
+        assert.equal(
+            startInteraction
+                .buildTransaction()
+                .getData()
+                .toString(),
+            "start@6c75636b79@0de0b6b3a7640000@@@0100000001@@"
+        );
         assert.isTrue(startReturnCode.equals(ReturnCode.Ok));
         assert.lengthOf(startReturnvalues, 0);
 
         // lotteryExists() (this is a view function, but for the sake of the test, we'll execute it)
-        let [, { returnCode: statusReturnCode, values: statusReturnvalues, firstValue: statusFirstValue }] = await Promise.all([
-            provider.mockNextTransactionTimeline([new TransactionStatus("executed"), new AddImmediateResult("@6f6b@01"), new MarkNotarized()]),
-            runner.runAwaitExecution(lotteryStatusInteraction.withNonce(new Nonce(15)))
+        let [
+            ,
+            { returnCode: statusReturnCode, values: statusReturnvalues, firstValue: statusFirstValue },
+        ] = await Promise.all([
+            provider.mockNextTransactionTimeline([
+                new TransactionStatus("executed"),
+                new AddImmediateResult("@6f6b@01"),
+                new MarkNotarized(),
+            ]),
+            runner.runAwaitExecution(lotteryStatusInteraction.withNonce(new Nonce(15))),
         ]);
 
-        assert.equal(lotteryStatusInteraction.buildTransaction().getData().toString(), "status@6c75636b79");
+        assert.equal(
+            lotteryStatusInteraction
+                .buildTransaction()
+                .getData()
+                .toString(),
+            "status@6c75636b79"
+        );
         assert.isTrue(statusReturnCode.equals(ReturnCode.Ok));
         assert.lengthOf(statusReturnvalues, 1);
-        assert.deepEqual(statusFirstValue.valueOf(), { name: "Running" });
+        assert.deepEqual(statusFirstValue.valueOf(), { name: "Running", fields: [] });
 
         // lotteryInfo() (this is a view function, but for the sake of the test, we'll execute it)
-        let [, { returnCode: infoReturnCode, values: infoReturnvalues, firstValue: infoFirstValue }] = await Promise.all([
-            provider.mockNextTransactionTimeline([new TransactionStatus("executed"), new AddImmediateResult("@6f6b@000000080de0b6b3a764000000000320000000006012a806000000010000000164000000000000000000000000"), new MarkNotarized()]),
-            runner.runAwaitExecution(getLotteryInfoInteraction.withNonce(new Nonce(16)))
+        let [
+            ,
+            { returnCode: infoReturnCode, values: infoReturnvalues, firstValue: infoFirstValue },
+        ] = await Promise.all([
+            provider.mockNextTransactionTimeline([
+                new TransactionStatus("executed"),
+                new AddImmediateResult(
+                    "@6f6b@000000080de0b6b3a764000000000320000000006012a806000000010000000164000000000000000000000000"
+                ),
+                new MarkNotarized(),
+            ]),
+            runner.runAwaitExecution(getLotteryInfoInteraction.withNonce(new Nonce(16))),
         ]);
 
-        assert.equal(getLotteryInfoInteraction.buildTransaction().getData().toString(), "lotteryInfo@6c75636b79");
+        assert.equal(
+            getLotteryInfoInteraction
+                .buildTransaction()
+                .getData()
+                .toString(),
+            "lotteryInfo@6c75636b79"
+        );
         assert.isTrue(infoReturnCode.equals(ReturnCode.Ok));
         assert.lengthOf(infoReturnvalues, 1);
 
@@ -174,7 +253,7 @@ describe("test smart contract interactor", function () {
             prize_distribution: Buffer.from([0x64]),
             whitelist: [],
             current_ticket_number: new BigNumber(0),
-            prize_pool: new BigNumber("0")
+            prize_pool: new BigNumber("0"),
         });
     });
 });

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -154,7 +154,7 @@ describe("test smart contract interactor", function () {
         assert.equal(lotteryStatusInteraction.buildTransaction().getData().toString(), "status@6c75636b79");
         assert.isTrue(statusReturnCode.equals(ReturnCode.Ok));
         assert.lengthOf(statusReturnvalues, 1);
-        assert.equal(statusFirstValue.valueOf(), "Running");
+        assert.deepEqual(statusFirstValue.valueOf(), { name: "Running" });
 
         // lotteryInfo() (this is a view function, but for the sake of the test, we'll execute it)
         let [, { returnCode: infoReturnCode, values: infoReturnvalues, firstValue: infoFirstValue }] = await Promise.all([

--- a/src/smartcontracts/typesystem/abiRegistry.spec.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.spec.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
 import { extendAbiRegistry, loadAbiRegistry } from "../../testutils";
+import { BinaryCodec } from "../codec";
 import { AbiRegistry } from "./abiRegistry";
 import { AddressType } from "./address";
 import { BytesType } from "./bytes";
@@ -35,7 +36,7 @@ describe("test abi registry", () => {
         let registry = await loadAbiRegistry([
             "src/testdata/answer.abi.json",
             "src/testdata/counter.abi.json",
-            "src/testdata/lottery_egld.abi.json"
+            "src/testdata/lottery_egld.abi.json",
         ]);
 
         // Ultimate answer
@@ -74,7 +75,10 @@ describe("test abi registry", () => {
 
     it("binary codec correctly decodes perform action result", async () => {
         let bc = new BinaryCodec();
-        let buff = Buffer.from("0588c738a5d26c0e3a2b4f9e8110b540ee9c0b71a3be057569a5a7b0fcb482c8f70000000806f05b59d3b200000000000b68656c6c6f20776f726c6400000000", "hex");
+        let buff = Buffer.from(
+            "0588c738a5d26c0e3a2b4f9e8110b540ee9c0b71a3be057569a5a7b0fcb482c8f70000000806f05b59d3b200000000000b68656c6c6f20776f726c6400000000",
+            "hex"
+        );
 
         let registry = await loadAbiRegistry(["src/testdata/multisig.abi.json"]);
         let multisig = registry.getInterface("Multisig");
@@ -82,7 +86,10 @@ describe("test abi registry", () => {
         assert.equal(performAction.output[0].type.getName(), "Action");
 
         let result = bc.decodeTopLevel(buff, performAction.output[0].type);
-        assert.equal(JSON.stringify(result), `{"type":{"name":"Action","typeParameters":[]},"name":"SendTransferExecute","discriminant":5}`);
-        assert.equal(result.valueOf().toString(), "SendTransferExecute");
+        assert.equal(
+            JSON.stringify(result),
+            `{"type":{"name":"Action","typeParameters":[]},"fields":[{"value":{"type":{"name":"CallActionData","typeParameters":[]},"fields":[{"value":{"type":{"name":"Address","typeParameters":[]},"value":{"bech32":"erd13rrn3fwjds8r5260n6q3pd2qa6wqkudrhczh26d957c0edyzermshds0k8","pubkey":"88c738a5d26c0e3a2b4f9e8110b540ee9c0b71a3be057569a5a7b0fcb482c8f7"}},"name":"to"},{"value":{"type":{"name":"BigUint","typeParameters":[]},"value":"500000000000000000","sizeInBytes":0,"withSign":false},"name":"egld_amount"},{"value":{"type":{"name":"bytes","typeParameters":[]},"value":{"type":"Buffer","data":[104,101,108,108,111,32,119,111,114,108,100]}},"name":"endpoint_name"},{"value":{"type":{"name":"List","typeParameters":[{"name":"bytes","typeParameters":[]}]},"items":[]},"name":"arguments"}]},"name":"0"}],"name":"SendTransferExecute","discriminant":5}`
+        );
+        assert.equal(result.valueOf().name, "SendTransferExecute");
     });
 });

--- a/src/smartcontracts/typesystem/abiRegistry.spec.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.spec.ts
@@ -7,7 +7,6 @@ import { EnumType } from "./enum";
 import { ListType, OptionType } from "./generic";
 import { BigUIntType, I64Type, U32Type, U8Type } from "./numerical";
 import { StructType } from "./struct";
-import { BinaryCodec } from "../codec";
 
 describe("test abi registry", () => {
     it("should extend", async () => {
@@ -28,7 +27,7 @@ describe("test abi registry", () => {
         assert.lengthOf(registry.customTypes, 2);
 
         assert.lengthOf(registry.getInterface("Lottery").endpoints, 6);
-        assert.lengthOf(registry.getStruct("LotteryInfo").fields, 8);
+        assert.lengthOf(registry.getStruct("LotteryInfo").getFieldsDefinitions(), 8);
         assert.lengthOf(registry.getEnum("Status").variants, 3);
     });
 
@@ -66,9 +65,11 @@ describe("test abi registry", () => {
         assert.instanceOf(getLotteryInfo.input[0].type, BytesType);
         assert.instanceOf(getLotteryInfo.output[0].type, StructType);
         assert.equal(getLotteryInfo.output[0].type.getName(), "LotteryInfo");
-        assert.instanceOf((<StructType>getLotteryInfo.output[0].type).fields[0].type, BigUIntType);
-        assert.instanceOf((<StructType>getLotteryInfo.output[0].type).fields[5].type, ListType);
-        assert.instanceOf((<StructType>getLotteryInfo.output[0].type).fields[5].type.getFirstTypeParameter(), AddressType);
+
+        let fieldDefinitions = (<StructType>getLotteryInfo.output[0].type).getFieldsDefinitions();
+        assert.instanceOf(fieldDefinitions[0].type, BigUIntType);
+        assert.instanceOf(fieldDefinitions[5].type, ListType);
+        assert.instanceOf(fieldDefinitions[5].type.getFirstTypeParameter(), AddressType);
     });
 
     it("binary codec correctly decodes perform action result", async () => {

--- a/src/smartcontracts/typesystem/enum.ts
+++ b/src/smartcontracts/typesystem/enum.ts
@@ -19,13 +19,13 @@ export class EnumType extends CustomType {
 
     getVariantByDiscriminant(discriminant: number): EnumVariantDefinition {
         let result = this.variants.find((e) => e.discriminant == discriminant);
-        guardValueIsSet("result", result);
+        guardValueIsSet(`variant by discriminant (${discriminant})`, result);
         return result!;
     }
 
     getVariantByName(name: string): EnumVariantDefinition {
         let result = this.variants.find((e) => e.name == name);
-        guardValueIsSet("result", result);
+        guardValueIsSet(`variant by name (${name})`, result);
         return result!;
     }
 }

--- a/src/smartcontracts/typesystem/enum.ts
+++ b/src/smartcontracts/typesystem/enum.ts
@@ -1,4 +1,5 @@
 import { guardTrue, guardValueIsSet } from "../../utils";
+import { Field, FieldDefinition, Fields } from "./fields";
 import { CustomType, TypedValue } from "./types";
 
 const SimpleEnumMaxDiscriminant = 256;
@@ -32,37 +33,51 @@ export class EnumType extends CustomType {
 export class EnumVariantDefinition {
     readonly name: string;
     readonly discriminant: number;
+    readonly fields: FieldDefinition[] = [];
 
-    constructor(name: string, discriminant: number) {
+    constructor(name: string, discriminant: number, fields: FieldDefinition[] = []) {
         guardTrue(discriminant < SimpleEnumMaxDiscriminant, `discriminant for simple enum should be less than ${SimpleEnumMaxDiscriminant}`);
 
         this.name = name;
         this.discriminant = discriminant;
+        this.fields = fields;
     }
 
-    static fromJSON(json: { name: string, discriminant: number }): EnumVariantDefinition {
-        return new EnumVariantDefinition(json.name, json.discriminant);
+    static fromJSON(json: { name: string, discriminant: number, fields: any[] }): EnumVariantDefinition {
+        let fields = (json.fields || []).map(field => FieldDefinition.fromJSON(field));
+        return new EnumVariantDefinition(json.name, json.discriminant, fields);
     }
 }
 
 export class EnumValue extends TypedValue {
     readonly name: string;
     readonly discriminant: number;
+    private readonly fields: Field[] = [];
 
-    private constructor(type: EnumType, variant: EnumVariantDefinition) {
+    private constructor(type: EnumType, variant: EnumVariantDefinition, fields: Field[]) {
         super(type);
         this.name = variant.name;
         this.discriminant = variant.discriminant;
+        this.fields = fields;
+
+        let definitions = variant.fields;
+        Fields.checkTyping(this.fields, definitions);
     }
 
+    /**
+     * Utility (named constructor) to create a simple (i.e. without fields) enum value.
+     */
     static fromName(type: EnumType, name: string): EnumValue {
         let variant = type.getVariantByName(name);
-        return new EnumValue(type, variant);
+        return new EnumValue(type, variant, []);
     }
 
+    /**
+     * Utility (named constructor) to create a simple (i.e. without fields) enum value.
+     */
     static fromDiscriminant(type: EnumType, discriminant: number): EnumValue {
         let variant = type.getVariantByDiscriminant(discriminant);
-        return new EnumValue(type, variant);
+        return new EnumValue(type, variant, []);
     }
 
     equals(other: EnumValue): boolean {
@@ -70,10 +85,29 @@ export class EnumValue extends TypedValue {
             return false;
         }
 
-        return this.name == other.name && this.discriminant == other.discriminant;
+        let selfFields = this.getFields();
+        let otherFields = other.getFields();
+
+        const nameIsSame = this.name == other.name;
+        const discriminantIsSame = this.discriminant == other.discriminant;
+        const fieldsAreSame = Fields.equals(selfFields, otherFields);
+
+        return nameIsSame && discriminantIsSame && fieldsAreSame;
+    }
+
+    getFields(): ReadonlyArray<Field> {
+        return this.fields;
     }
 
     valueOf() {
-        return this.name;
+        let result: any = { name: this.name};
+
+        if (this.fields.length === 0) {
+            return result;
+        }
+
+        this.fields.forEach(field => result.fields[field.name] = field.value.valueOf());
+        
+        return result;
     }
 }

--- a/src/smartcontracts/typesystem/enum.ts
+++ b/src/smartcontracts/typesystem/enum.ts
@@ -33,19 +33,23 @@ export class EnumType extends CustomType {
 export class EnumVariantDefinition {
     readonly name: string;
     readonly discriminant: number;
-    readonly fields: FieldDefinition[] = [];
+    private readonly fieldsDefinitions: FieldDefinition[] = [];
 
-    constructor(name: string, discriminant: number, fields: FieldDefinition[] = []) {
+    constructor(name: string, discriminant: number, fieldsDefinitions: FieldDefinition[] = []) {
         guardTrue(discriminant < SimpleEnumMaxDiscriminant, `discriminant for simple enum should be less than ${SimpleEnumMaxDiscriminant}`);
 
         this.name = name;
         this.discriminant = discriminant;
-        this.fields = fields;
+        this.fieldsDefinitions = fieldsDefinitions;
     }
 
     static fromJSON(json: { name: string, discriminant: number, fields: any[] }): EnumVariantDefinition {
-        let fields = (json.fields || []).map(field => FieldDefinition.fromJSON(field));
-        return new EnumVariantDefinition(json.name, json.discriminant, fields);
+        let definitions = (json.fields || []).map(definition => FieldDefinition.fromJSON(definition));
+        return new EnumVariantDefinition(json.name, json.discriminant, definitions);
+    }
+
+    getFieldsDefinitions() {
+        return this.fieldsDefinitions;
     }
 }
 
@@ -54,13 +58,13 @@ export class EnumValue extends TypedValue {
     readonly discriminant: number;
     private readonly fields: Field[] = [];
 
-    private constructor(type: EnumType, variant: EnumVariantDefinition, fields: Field[]) {
+    constructor(type: EnumType, variant: EnumVariantDefinition, fields: Field[]) {
         super(type);
         this.name = variant.name;
         this.discriminant = variant.discriminant;
         this.fields = fields;
 
-        let definitions = variant.fields;
+        let definitions = variant.getFieldsDefinitions();
         Fields.checkTyping(this.fields, definitions);
     }
 

--- a/src/smartcontracts/typesystem/enum.ts
+++ b/src/smartcontracts/typesystem/enum.ts
@@ -12,19 +12,19 @@ export class EnumType extends CustomType {
         this.variants = variants;
     }
 
-    static fromJSON(json: { name: string, variants: any[] }): EnumType {
-        let variants = (json.variants || []).map(variant => EnumVariantDefinition.fromJSON(variant));
+    static fromJSON(json: { name: string; variants: any[] }): EnumType {
+        let variants = (json.variants || []).map((variant) => EnumVariantDefinition.fromJSON(variant));
         return new EnumType(json.name, variants);
     }
 
     getVariantByDiscriminant(discriminant: number): EnumVariantDefinition {
-        let result = this.variants.find(e => e.discriminant == discriminant);
+        let result = this.variants.find((e) => e.discriminant == discriminant);
         guardValueIsSet("result", result);
         return result!;
     }
 
     getVariantByName(name: string): EnumVariantDefinition {
-        let result = this.variants.find(e => e.name == name);
+        let result = this.variants.find((e) => e.name == name);
         guardValueIsSet("result", result);
         return result!;
     }
@@ -36,15 +36,18 @@ export class EnumVariantDefinition {
     private readonly fieldsDefinitions: FieldDefinition[] = [];
 
     constructor(name: string, discriminant: number, fieldsDefinitions: FieldDefinition[] = []) {
-        guardTrue(discriminant < SimpleEnumMaxDiscriminant, `discriminant for simple enum should be less than ${SimpleEnumMaxDiscriminant}`);
+        guardTrue(
+            discriminant < SimpleEnumMaxDiscriminant,
+            `discriminant for simple enum should be less than ${SimpleEnumMaxDiscriminant}`
+        );
 
         this.name = name;
         this.discriminant = discriminant;
         this.fieldsDefinitions = fieldsDefinitions;
     }
 
-    static fromJSON(json: { name: string, discriminant: number, fields: any[] }): EnumVariantDefinition {
-        let definitions = (json.fields || []).map(definition => FieldDefinition.fromJSON(definition));
+    static fromJSON(json: { name: string; discriminant: number; fields: any[] }): EnumVariantDefinition {
+        let definitions = (json.fields || []).map((definition) => FieldDefinition.fromJSON(definition));
         return new EnumVariantDefinition(json.name, json.discriminant, definitions);
     }
 
@@ -104,14 +107,10 @@ export class EnumValue extends TypedValue {
     }
 
     valueOf() {
-        let result: any = { name: this.name};
+        let result: any = { name: this.name, fields: [] };
 
-        if (this.fields.length === 0) {
-            return result;
-        }
+        this.fields.forEach((field) => (result.fields[field.name] = field.value.valueOf()));
 
-        this.fields.forEach(field => result.fields[field.name] = field.value.valueOf());
-        
         return result;
     }
 }

--- a/src/smartcontracts/typesystem/fields.ts
+++ b/src/smartcontracts/typesystem/fields.ts
@@ -1,0 +1,77 @@
+import * as errors from "../../errors";
+import { TypeExpressionParser } from "./typeExpressionParser";
+import { Type, TypedValue } from "./types";
+
+export class FieldDefinition {
+    readonly name: string;
+    readonly description: string;
+    readonly type: Type;
+
+    constructor(name: string, description: string, type: Type) {
+        this.name = name;
+        this.description = description;
+        this.type = type;
+    }
+
+    static fromJSON(json: { name: string, description: string, type: string }): FieldDefinition {
+        let parsedType = new TypeExpressionParser().parse(json.type);
+        return new FieldDefinition(json.name, json.description, parsedType);
+    }
+}
+
+export class Field {
+    readonly value: TypedValue;
+    readonly name: string;
+
+    constructor(value: TypedValue, name: string = "") {
+        this.value = value;
+        this.name = name;
+    }
+
+    checkTyping(expectedDefinition: FieldDefinition) {
+        const actualType: Type = this.value.getType();
+
+        if (!actualType.equals(expectedDefinition.type)) {
+            throw new errors.ErrTypingSystem(`check type of field "${expectedDefinition.name}; expected: ${expectedDefinition.type}, actual: ${actualType}"`);
+        }
+        if (this.name != expectedDefinition.name) {
+            throw new errors.ErrTypingSystem(`check name of field "${expectedDefinition.name}"`);
+        }
+    }
+
+    equals(other: Field) {
+        return this.name == other.name && this.value.equals(other.value);
+    }
+}
+
+export class Fields {
+    static checkTyping(fields: Field[], definitions: FieldDefinition[]) {
+        if (fields.length != definitions.length) {
+            throw new errors.ErrTypingSystem("fields length vs. field definitions length");
+        }
+
+        for (let i = 0; i < fields.length; i++) {
+            let field = fields[i];
+            let definition = definitions[i];
+            
+            field.checkTyping(definition);
+        }
+    }
+
+    static equals(actual: ReadonlyArray<Field>, expected: ReadonlyArray<Field>): boolean {
+        if (actual.length != expected.length) {
+            return false;
+        }
+
+        for (let i = 0; i < actual.length; i++) {
+            let selfField = actual[i];
+            let otherField = expected[i];
+
+            if (!selfField.equals(otherField)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/smartcontracts/typesystem/index.ts
+++ b/src/smartcontracts/typesystem/index.ts
@@ -16,6 +16,7 @@ export * from "./fields";
 export * from "./generic";
 export * from "./h256";
 export * from "./matchers";
+export * from "./nothing";
 export * from "./numerical";
 export * from "./string";
 export * from "./struct";

--- a/src/smartcontracts/typesystem/index.ts
+++ b/src/smartcontracts/typesystem/index.ts
@@ -12,6 +12,7 @@ export * from "./composite";
 export * from "./contractInterface";
 export * from "./endpoint";
 export * from "./enum";
+export * from "./fields";
 export * from "./generic";
 export * from "./h256";
 export * from "./matchers";

--- a/src/smartcontracts/typesystem/matchers.ts
+++ b/src/smartcontracts/typesystem/matchers.ts
@@ -6,6 +6,7 @@ import { EnumType, EnumValue } from "./enum";
 import { OptionType, OptionValue, List, ListType } from "./generic";
 import { H256Type, H256Value } from "./h256";
 import { NumericalType, NumericalValue } from "./numerical";
+import { NothingType, NothingValue } from "./nothing";
 import { Struct, StructType } from "./struct";
 import { TokenIdentifierType, TokenIdentifierValue } from "./tokenIdentifier";
 import { Tuple, TupleType } from "./tuple";
@@ -80,6 +81,7 @@ export function onTypedValueSelect<TResult>(
     if (value instanceof EnumValue) {
         return selectors.onEnum();
     }
+
     if (selectors.onOther) {
         return selectors.onOther();
     }
@@ -96,6 +98,7 @@ export function onPrimitiveValueSelect<TResult>(
         onBytes: () => TResult;
         onH256: () => TResult;
         onTypeIdentifier: () => TResult;
+        onNothing: () => TResult;
         onOther?: () => TResult;
     }
 ): TResult {
@@ -117,6 +120,9 @@ export function onPrimitiveValueSelect<TResult>(
     if (value instanceof TokenIdentifierValue) {
         return selectors.onTypeIdentifier();
     }
+    if (value instanceof NothingValue) {
+        return selectors.onNothing();
+    }
     if (selectors.onOther) {
         return selectors.onOther();
     }
@@ -133,6 +139,7 @@ export function onPrimitiveTypeSelect<TResult>(
         onBytes: () => TResult;
         onH256: () => TResult;
         onTokenIndetifier: () => TResult;
+        onNothing: () => TResult;
         onOther?: () => TResult;
     }
 ): TResult {
@@ -153,6 +160,9 @@ export function onPrimitiveTypeSelect<TResult>(
     }
     if (type instanceof TokenIdentifierType) {
         return selectors.onTokenIndetifier();
+    }
+    if (type instanceof NothingType) {
+        return selectors.onNothing();
     }
     if (selectors.onOther) {
         return selectors.onOther();

--- a/src/smartcontracts/typesystem/nothing.ts
+++ b/src/smartcontracts/typesystem/nothing.ts
@@ -1,0 +1,21 @@
+import { PrimitiveType, PrimitiveValue } from "./types";
+
+export class NothingType extends PrimitiveType {
+    constructor() {
+        super("nothing");
+    }
+}
+
+export class NothingValue extends PrimitiveValue {
+    constructor() {
+        super(new NothingType());
+    }
+
+    equals(_other: NothingValue): boolean {
+        return false;
+    }
+
+    valueOf(): any {
+        return {};
+    }
+}

--- a/src/smartcontracts/typesystem/struct.ts
+++ b/src/smartcontracts/typesystem/struct.ts
@@ -2,16 +2,20 @@ import { FieldDefinition, Field, Fields } from "./fields";
 import { CustomType, TypedValue } from "./types";
 
 export class StructType extends CustomType {
-    readonly fields: FieldDefinition[] = [];
+    private readonly fieldsDefinitions: FieldDefinition[] = [];
 
-    constructor(name: string, fields: FieldDefinition[]) {
+    constructor(name: string, fieldsDefinitions: FieldDefinition[]) {
         super(name);
-        this.fields = fields;
+        this.fieldsDefinitions = fieldsDefinitions;
     }
 
     static fromJSON(json: { name: string, fields: any[] }): StructType {
-        let fields = (json.fields || []).map(field => FieldDefinition.fromJSON(field));
-        return new StructType(json.name, fields);
+        let definitions = (json.fields || []).map(definition => FieldDefinition.fromJSON(definition));
+        return new StructType(json.name, definitions);
+    }
+
+    getFieldsDefinitions() {
+        return this.fieldsDefinitions;
     }
 }
 
@@ -32,7 +36,7 @@ export class Struct extends TypedValue {
 
     private checkTyping() {
         let type = <StructType>this.getType();
-        let definitions = type.fields;
+        let definitions = type.getFieldsDefinitions();
         Fields.checkTyping(this.fields, definitions);
     }
 

--- a/src/smartcontracts/typesystem/struct.ts
+++ b/src/smartcontracts/typesystem/struct.ts
@@ -1,48 +1,29 @@
-import * as errors from "../../errors";
-import { TypeExpressionParser } from "./typeExpressionParser";
-import { Type, CustomType, TypedValue } from "./types";
+import { FieldDefinition, Field, Fields } from "./fields";
+import { CustomType, TypedValue } from "./types";
 
 export class StructType extends CustomType {
-    readonly fields: StructFieldDefinition[] = [];
+    readonly fields: FieldDefinition[] = [];
 
-    constructor(name: string, fields: StructFieldDefinition[]) {
+    constructor(name: string, fields: FieldDefinition[]) {
         super(name);
         this.fields = fields;
     }
 
     static fromJSON(json: { name: string, fields: any[] }): StructType {
-        let fields = (json.fields || []).map(field => StructFieldDefinition.fromJSON(field));
+        let fields = (json.fields || []).map(field => FieldDefinition.fromJSON(field));
         return new StructType(json.name, fields);
-    }
-}
-
-// TODO: Perhaps rename to FieldDefinition and extract to separate file, fields.ts?
-export class StructFieldDefinition {
-    readonly name: string;
-    readonly description: string;
-    readonly type: Type;
-
-    constructor(name: string, description: string, type: Type) {
-        this.name = name;
-        this.description = description;
-        this.type = type;
-    }
-
-    static fromJSON(json: { name: string, description: string, type: string }): StructFieldDefinition {
-        let parsedType = new TypeExpressionParser().parse(json.type);
-        return new StructFieldDefinition(json.name, json.description, parsedType);
     }
 }
 
 // TODO: implement setField(), convenience method.
 // TODO: Hold fields in a map (by name), and use the order within "field definitions" to perform codec operations.
 export class Struct extends TypedValue {
-    private readonly fields: StructField[] = [];
+    private readonly fields: Field[] = [];
 
     /**
      * Currently, one can only set fields at initialization time. Construction will be improved at a later time.
      */
-    constructor(type: StructType, fields: StructField[]) {
+    constructor(type: StructType, fields: Field[]) {
         super(type);
         this.fields = fields;
 
@@ -50,30 +31,12 @@ export class Struct extends TypedValue {
     }
 
     private checkTyping() {
-        let fields = this.fields;
         let type = <StructType>this.getType();
         let definitions = type.fields;
-
-        if (fields.length != definitions.length) {
-            throw new errors.ErrStructTyping("fields length vs. field definitions length");
-        }
-
-        for (let i = 0; i < fields.length; i++) {
-            let field = fields[i];
-            let definition = definitions[i];
-            let fieldType = field.value.getType();
-            let definitionType = definition.type;
-
-            if (!fieldType.equals(definitionType)) {
-                throw new errors.ErrStructTyping(`check type of field "${definition.name}; expected: ${definitionType}, actual: ${fieldType}"`);
-            }
-            if (field.name != definition.name) {
-                throw new errors.ErrStructTyping(`check name of field "${definition.name}"`);
-            }
-        }
+        Fields.checkTyping(this.fields, definitions);
     }
 
-    getFields(): ReadonlyArray<StructField> {
+    getFields(): ReadonlyArray<Field> {
         return this.fields;
     }
 
@@ -86,7 +49,7 @@ export class Struct extends TypedValue {
 
         return result;
     }
-
+    
     equals(other: Struct): boolean {
         if (!this.getType().equals(other.getType())) {
             return false;
@@ -95,35 +58,6 @@ export class Struct extends TypedValue {
         let selfFields = this.getFields();
         let otherFields = other.getFields();
 
-        if (selfFields.length != otherFields.length) {
-            return false;
-        }
-
-        for (let i = 0; i < selfFields.length; i++) {
-            let selfField = selfFields[i];
-            let otherField = otherFields[i];
-
-            if (!selfField.equals(otherField)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-}
-
-
-// TODO: Perhaps rename to Field and extract to separate file, fields.ts?
-export class StructField {
-    readonly value: TypedValue;
-    readonly name: string;
-
-    constructor(value: TypedValue, name: string = "") {
-        this.value = value;
-        this.name = name;
-    }
-
-    equals(other: StructField) {
-        return this.name == other.name && this.value.equals(other.value);
+        return Fields.equals(selfFields, otherFields);
     }
 }

--- a/src/smartcontracts/typesystem/tuple.ts
+++ b/src/smartcontracts/typesystem/tuple.ts
@@ -1,5 +1,6 @@
 import * as errors from "../../errors";
-import { Struct, StructField, StructFieldDefinition } from "./struct";
+import { Struct } from "./struct";
+import { FieldDefinition, Field } from "./fields";
 import { Type, TypedValue } from "./types";
 import { StructType } from "./struct";
 
@@ -14,8 +15,8 @@ export class TupleType extends StructType {
         return result;
     }
 
-    private static prepareFieldDefinitions(typeParameters: Type[]): StructFieldDefinition[] {
-        let result = typeParameters.map((type, i) => new StructFieldDefinition(prepareFieldName(i), "anonymous tuple field", type));
+    private static prepareFieldDefinitions(typeParameters: Type[]): FieldDefinition[] {
+        let result = typeParameters.map((type, i) => new FieldDefinition(prepareFieldName(i), "anonymous tuple field", type));
         return result;
     }
 }
@@ -28,7 +29,7 @@ function prepareFieldName(fieldIndex: number) {
 // Or let Tuple be the base class, but have Struct as a specialization of it, "named tuple"?
 // Or leave as it is?
 export class Tuple extends Struct {
-    constructor(type: TupleType, fields: StructField[]) {
+    constructor(type: TupleType, fields: Field[]) {
         super(type, fields);
     }
 
@@ -40,7 +41,7 @@ export class Tuple extends Struct {
         
         let fieldsTypes = items.map(item => item.getType());
         let tupleType = new TupleType(...fieldsTypes);
-        let fields = items.map((item, i) => new StructField(item, prepareFieldName(i)));
+        let fields = items.map((item, i) => new Field(item, prepareFieldName(i)));
         
         return new Tuple(tupleType, fields);
     }

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -18,7 +18,8 @@ import {
     U64Type,
     U8Type,
 } from "./numerical";
-import { StructFieldDefinition, StructType } from "./struct";
+import { StructType } from "./struct";
+import { FieldDefinition } from "./fields";
 import { TokenIdentifierType } from "./tokenIdentifier";
 import { Type, CustomType } from "./types";
 import { VariadicType } from "./variadic";
@@ -118,7 +119,7 @@ export class TypeMapper {
 
     private mapStructType(type: StructType): StructType {
         let mappedFields = type.fields.map(
-            (item) => new StructFieldDefinition(item.name, item.description, this.mapType(item.type))
+            (item) => new FieldDefinition(item.name, item.description, this.mapType(item.type))
         );
         let mappedStruct = new StructType(type.getName(), mappedFields);
         return mappedStruct;

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -26,6 +26,7 @@ import { VariadicType } from "./variadic";
 import { OptionalType } from "./algebraic";
 import { StringType, TupleType } from ".";
 import { CodeMetadataType } from "./codeMetadata";
+import { NothingType } from "./nothing";
 
 type TypeConstructor = new (...typeParameters: Type[]) => Type;
 
@@ -80,6 +81,8 @@ export class TypeMapper {
             ["utf-8 string", new StringType()],
             ["TokenIdentifier", new TokenIdentifierType()],
             ["CodeMetadata", new CodeMetadataType()],
+            ["nothing", new NothingType()],
+            ["AsyncCall", new NothingType()]
         ]);
 
         for (const customType of customTypes) {

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -118,8 +118,8 @@ export class TypeMapper {
     }
 
     private mapStructType(type: StructType): StructType {
-        let mappedFields = type.fields.map(
-            (item) => new FieldDefinition(item.name, item.description, this.mapType(item.type))
+        let mappedFields = type.getFieldsDefinitions().map(
+            (definition) => new FieldDefinition(definition.name, definition.description, this.mapType(definition.type))
         );
         let mappedStruct = new StructType(type.getName(), mappedFields);
         return mappedStruct;

--- a/src/smartcontracts/wrapper/contractWrapper.spec.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.spec.ts
@@ -62,7 +62,7 @@ describe("test smart contract wrapper", async function () {
         await mockCall(provider, "@6f6b", lottery.call.start("lucky", Egld(1), null, null, 1, null, null));
 
         let status = await mockCall(provider, "@6f6b@01", lottery.call.status("lucky"));
-        assert.equal(status, "Running");
+        assert.deepEqual(status, { name: "Running" });
 
         let info = await mockCall(
             provider,

--- a/src/smartcontracts/wrapper/contractWrapper.spec.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.spec.ts
@@ -1,4 +1,10 @@
-import { AddImmediateResult, MarkNotarized, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
+import {
+    AddImmediateResult,
+    MarkNotarized,
+    MockProvider,
+    setupUnitTestWatcherTimeouts,
+    TestWallet,
+} from "../../testutils";
 import { Address } from "../../address";
 import { assert } from "chai";
 import { QueryResponse } from "../queryResponse";
@@ -8,20 +14,26 @@ import BigNumber from "bignumber.js";
 import { SystemWrapper } from "./systemWrapper";
 import { Egld, setupInteractiveWithProvider } from "../..";
 
-describe("test smart contract wrapper", async function () {
+describe("test smart contract wrapper", async function() {
     let dummyAddress = new Address("erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3");
     let erdSys: SystemWrapper;
     let provider = new MockProvider();
     let alice: TestWallet;
-    before(async function () {
-        ({ erdSys, wallets: { alice } } = await setupInteractiveWithProvider(provider));
+    before(async function() {
+        ({
+            erdSys,
+            wallets: { alice },
+        } = await setupInteractiveWithProvider(provider));
     });
 
-    it("should interact with 'answer'", async function () {
+    it("should interact with 'answer'", async function() {
         setupUnitTestWatcherTimeouts();
 
         let answer = await erdSys.loadWrapper("src/testdata", "answer");
-        answer.address(dummyAddress).sender(alice).gas(500_000);
+        answer
+            .address(dummyAddress)
+            .sender(alice)
+            .gas(500_000);
 
         mockQuery(provider, "getUltimateAnswer", "Kg==");
 
@@ -32,11 +44,14 @@ describe("test smart contract wrapper", async function () {
         assert.deepEqual(callResult, new BigNumber(43));
     });
 
-    it("should interact with 'counter'", async function () {
+    it("should interact with 'counter'", async function() {
         setupUnitTestWatcherTimeouts();
 
         let counter = await erdSys.loadWrapper("src/testdata", "counter");
-        counter.address(dummyAddress).sender(alice).gas(500_000);
+        counter
+            .address(dummyAddress)
+            .sender(alice)
+            .gas(500_000);
 
         // For "get()", return fake 7
         mockQuery(provider, "get", "Bw==");
@@ -53,16 +68,19 @@ describe("test smart contract wrapper", async function () {
         assert.deepEqual(decrementResult, new BigNumber(7));
     });
 
-    it("should interact with 'lottery_egld'", async function () {
+    it("should interact with 'lottery_egld'", async function() {
         setupUnitTestWatcherTimeouts();
 
         let lottery = await erdSys.loadWrapper("src/testdata", "lottery_egld");
-        lottery.address(dummyAddress).sender(alice).gas(5_000_000);
+        lottery
+            .address(dummyAddress)
+            .sender(alice)
+            .gas(5_000_000);
 
         await mockCall(provider, "@6f6b", lottery.call.start("lucky", Egld(1), null, null, 1, null, null));
 
         let status = await mockCall(provider, "@6f6b@01", lottery.call.status("lucky"));
-        assert.deepEqual(status, { name: "Running" });
+        assert.deepEqual(status, { name: "Running", fields: [] });
 
         let info = await mockCall(
             provider,
@@ -78,19 +96,26 @@ describe("test smart contract wrapper", async function () {
             prize_distribution: Buffer.from([0x64]),
             whitelist: [],
             current_ticket_number: new BigNumber(0),
-            prize_pool: new BigNumber("0")
+            prize_pool: new BigNumber("0"),
         });
     });
 });
 
 function mockQuery(provider: MockProvider, functionName: string, mockedResult: string) {
-    provider.mockQueryResponseOnFunction(functionName, new QueryResponse({ returnData: [mockedResult], returnCode: ReturnCode.Ok }));
+    provider.mockQueryResponseOnFunction(
+        functionName,
+        new QueryResponse({ returnData: [mockedResult], returnCode: ReturnCode.Ok })
+    );
 }
 
 async function mockCall(provider: MockProvider, mockedResult: string, promise: Promise<any>) {
     let [, value] = await Promise.all([
-        provider.mockNextTransactionTimeline([new TransactionStatus("executed"), new AddImmediateResult(mockedResult), new MarkNotarized()]),
-        promise
+        provider.mockNextTransactionTimeline([
+            new TransactionStatus("executed"),
+            new AddImmediateResult(mockedResult),
+            new MarkNotarized(),
+        ]),
+        promise,
     ]);
     return value;
 }

--- a/src/testdata/multisig.abi.json
+++ b/src/testdata/multisig.abi.json
@@ -559,6 +559,27 @@
     ],
     "hasCallback": false,
     "types": {
+        "CallActionData": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "to",
+                    "type": "Address"
+                },
+                {
+                    "name": "egld_amount",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "endpoint_name",
+                    "type": "bytes"
+                },
+                {
+                    "name": "arguments",
+                    "type": "List<bytes>"
+                }
+            ]
+        },
         "Action": {
             "type": "enum",
             "variants": [
@@ -693,27 +714,6 @@
                 {
                     "name": "signers",
                     "type": "List<Address>"
-                }
-            ]
-        },
-        "CallActionData": {
-            "type": "struct",
-            "fields": [
-                {
-                    "name": "to",
-                    "type": "Address"
-                },
-                {
-                    "name": "egld_amount",
-                    "type": "BigUint"
-                },
-                {
-                    "name": "endpoint_name",
-                    "type": "bytes"
-                },
-                {
-                    "name": "arguments",
-                    "type": "List<bytes>"
                 }
             ]
         },


### PR DESCRIPTION
(Pair programming, @danielailie and @andreibancioiu)

 - `typesystem/enum` and `codec/enum` (and `typeMapper`) have been adjusted to support (heterogeneous) enums with fields.
 - `typesystem/structs` and `typesystem/enum` have been refactored to rely on `typesystem/fields`.
 - `codec/structs` and `codec/enum` have been refactored to rely on `codec/fields`.
 - `AsyncCall` ABI type is handled as `Nothing` (`NothingType`, `NothingValue`).

**Breaking changes**
 - `ErrStructTyping` has been removed
 - `EnumValue.valueOf()` does not return a string (the name of the variant) anymore. It returns a JS object such as `{"name": "name of variant", "fields": { ... }}`
 - `StructFieldDefinition` has been replaced by `FieldDefinition`, while `StructField` has been replaced by `Field`.