### PR TITLE
Fix / skip (some) browser tests

### DIFF
--- a/src/balance.spec.ts
+++ b/src/balance.spec.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import { Balance } from "./balance";
-import { Egld } from "./balanceBuilder";
+import { createBalanceBuilder, Egld } from "./balanceBuilder";
+import { Token, TokenType } from "./token";
 
 describe("test balance", () => {
     it("should have desired precision", () => {
@@ -33,5 +34,11 @@ describe("test balance", () => {
         assert.equal(Egld(0.01).toDenominated(), "0.010000000000000000");
         assert.equal(Egld.raw('5000000000000000042').toDenominated(), "5.000000000000000042");
         assert.equal(Egld.raw('1000000000').toDenominated(), "0.000000001000000000");
+    });
+
+    it("test USDT builder", () => {
+        const USDTToken = createBalanceBuilder(new Token({ identifier: "USDT", name: "USDT", decimals: 6, type: TokenType.Fungible }));
+        assert.equal(USDTToken(10).toDenominated(), "10.000000");
+        assert.equal(USDTToken(10).toString(), "10000000");
     });
 });

--- a/src/dapp/walletProvider.spec.ts
+++ b/src/dapp/walletProvider.spec.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 import {WalletProvider} from "./walletProvider";
 import {Transaction} from "../transaction";
 import {Address} from "../address";
+import { isBrowser } from "../testutils";
 
 declare global {
   namespace NodeJS {
@@ -16,15 +17,26 @@ declare global {
 }
 
 describe("test wallet provider", () => {
-  beforeEach(() => {
+  before(function() {
+    if (isBrowser()) {
+      this.skip();
+    }
+  });
+
+  beforeEach(function() {
     global.window = {
       location: {
         href: "http://return-to-wallet"
       }
     };
   });
-  after(() => {
-    delete global.window;
+
+  after(function() {
+    if (isBrowser()) {
+      // Do nothing.
+    } else {
+      delete global.window;
+    }
   });
 
   it('login redirects correctly', async () => {

--- a/src/dapp/walletProvider.spec.ts
+++ b/src/dapp/walletProvider.spec.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import {WalletProvider} from "./walletProvider";
 import {Transaction} from "../transaction";
 import {Address} from "../address";
-import { isBrowser } from "../testutils";
+import { isOnBrowserTests } from "../testutils";
 
 declare global {
   namespace NodeJS {
@@ -18,7 +18,7 @@ declare global {
 
 describe("test wallet provider", () => {
   before(function() {
-    if (isBrowser()) {
+    if (isOnBrowserTests()) {
       this.skip();
     }
   });
@@ -32,7 +32,7 @@ describe("test wallet provider", () => {
   });
 
   after(function() {
-    if (isBrowser()) {
+    if (isOnBrowserTests()) {
       // Do nothing.
     } else {
       delete global.window;

--- a/src/smartcontracts/wrapper/contractWrapper.spec.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.spec.ts
@@ -1,4 +1,4 @@
-import { AddImmediateResult, MarkNotarized, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
+import { AddImmediateResult, isBrowser, MarkNotarized, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
 import { Address } from "../../address";
 import { assert } from "chai";
 import { QueryResponse } from "../queryResponse";
@@ -14,6 +14,10 @@ describe("test smart contract wrapper", async function () {
     let provider = new MockProvider();
     let alice: TestWallet;
     before(async function () {
+        if (isBrowser()) {
+            this.skip();
+        }
+
         ({ erdSys, wallets: { alice } } = await setupInteractiveWithProvider(provider));
     });
 

--- a/src/smartcontracts/wrapper/contractWrapper.spec.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.spec.ts
@@ -1,4 +1,4 @@
-import { AddImmediateResult, isBrowser, MarkNotarized, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
+import { AddImmediateResult, isOnBrowserTests, MarkNotarized, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
 import { Address } from "../../address";
 import { assert } from "chai";
 import { QueryResponse } from "../queryResponse";
@@ -14,7 +14,7 @@ describe("test smart contract wrapper", async function () {
     let provider = new MockProvider();
     let alice: TestWallet;
     before(async function () {
-        if (isBrowser()) {
+        if (isOnBrowserTests()) {
             this.skip();
         }
 

--- a/src/smartcontracts/wrapper/esdt.spec.ts
+++ b/src/smartcontracts/wrapper/esdt.spec.ts
@@ -1,5 +1,5 @@
 import { Address, ContractWrapper, createBalanceBuilder, Egld, Token, SystemWrapper, TokenType, setupInteractiveWithProvider } from "../..";
-import { MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
+import { isBrowser, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
 import { assert } from "chai";
 
 describe("test ESDT transfers via the smart contract wrapper", async function () {
@@ -9,6 +9,10 @@ describe("test ESDT transfers via the smart contract wrapper", async function ()
     let alice: TestWallet;
     let market: ContractWrapper;
     before(async function () {
+        if (isBrowser()) {
+            this.skip();
+        }
+        
         ({ erdSys, wallets: { alice } } = await setupInteractiveWithProvider(provider));
         market = await erdSys.loadWrapper("src/testdata", "esdt-nft-marketplace");
         market.address(dummyAddress).sender(alice).gas(500_000);

--- a/src/smartcontracts/wrapper/esdt.spec.ts
+++ b/src/smartcontracts/wrapper/esdt.spec.ts
@@ -1,5 +1,5 @@
 import { Address, ContractWrapper, createBalanceBuilder, Egld, Token, SystemWrapper, TokenType, setupInteractiveWithProvider } from "../..";
-import { isBrowser, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
+import { isOnBrowserTests, MockProvider, setupUnitTestWatcherTimeouts, TestWallet } from "../../testutils";
 import { assert } from "chai";
 
 describe("test ESDT transfers via the smart contract wrapper", async function () {
@@ -9,10 +9,10 @@ describe("test ESDT transfers via the smart contract wrapper", async function ()
     let alice: TestWallet;
     let market: ContractWrapper;
     before(async function () {
-        if (isBrowser()) {
+        if (isOnBrowserTests()) {
             this.skip();
         }
-        
+
         ({ erdSys, wallets: { alice } } = await setupInteractiveWithProvider(provider));
         market = await erdSys.loadWrapper("src/testdata", "esdt-nft-marketplace");
         market.address(dummyAddress).sender(alice).gas(500_000);

--- a/src/testutils/utils.ts
+++ b/src/testutils/utils.ts
@@ -32,7 +32,7 @@ export async function extendAbiRegistry(registry: AbiRegistry, path: PathLike): 
 }
 
 export function isBrowser() {
-    return typeof window !== "undefined";
+    return typeof window !== "undefined" && window.location.href.includes("browser-tests");
 }
 
 export function setupUnitTestWatcherTimeouts() {

--- a/src/testutils/utils.ts
+++ b/src/testutils/utils.ts
@@ -31,7 +31,7 @@ export async function extendAbiRegistry(registry: AbiRegistry, path: PathLike): 
     return registry.extendFromFile(source);
 }
 
-function isBrowser() {
+export function isBrowser() {
     return typeof window !== "undefined";
 }
 

--- a/src/testutils/utils.ts
+++ b/src/testutils/utils.ts
@@ -4,7 +4,7 @@ import { AbiRegistry } from "../smartcontracts/typesystem";
 import { TransactionWatcher } from "../transactionWatcher";
 
 export async function loadContractCode(path: PathLike): Promise<Code> {
-    if (isBrowser()) {
+    if (isOnBrowserTests()) {
         return Code.fromUrl(path.toString());
     }
 
@@ -14,7 +14,7 @@ export async function loadContractCode(path: PathLike): Promise<Code> {
 export async function loadAbiRegistry(paths: PathLike[]): Promise<AbiRegistry> {
     let sources = paths.map(e => e.toString());
 
-    if (isBrowser()) {
+    if (isOnBrowserTests()) {
         return AbiRegistry.load({ urls: sources });
     }
 
@@ -24,15 +24,23 @@ export async function loadAbiRegistry(paths: PathLike[]): Promise<AbiRegistry> {
 export async function extendAbiRegistry(registry: AbiRegistry, path: PathLike): Promise<AbiRegistry> {
     let source = path.toString();
 
-    if (isBrowser()) {
+    if (isOnBrowserTests()) {
         return registry.extendFromUrl(source);
     }
 
     return registry.extendFromFile(source);
 }
 
-export function isBrowser() {
-    return typeof window !== "undefined" && window.location.href.includes("browser-tests");
+export function isOnBrowserTests() {
+    const BROWSER_TESTS_URL = "browser-tests";
+
+    let noWindow = typeof window === "undefined";
+    if (noWindow) {
+        return false;
+    }
+
+    let isOnTests = window.location.href.includes(BROWSER_TESTS_URL);
+    return isOnTests;
 }
 
 export function setupUnitTestWatcherTimeouts() {

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import * as fs from "fs";
 import * as path from "path";
 import { Account } from "../account";
@@ -5,6 +6,7 @@ import { Address } from "../address";
 import { IProvider, ISigner } from "../interface";
 import { UserSecretKey } from "../walletcore";
 import { UserSigner } from "../walletcore/userSigner";
+import { isBrowser } from "./utils";
 
 export async function loadAndSyncTestWallets(provider: IProvider): Promise<Record<string, TestWallet>> {
     let wallets = await loadTestWallets();
@@ -46,9 +48,19 @@ export async function loadTestWallet(name: string): Promise<TestWallet> {
 }
 
 async function readTestWalletFileContents(name: string): Promise<string> {
-    let basePath = path.join(__dirname, "testwallets");
-    let filePath = path.join(basePath, name);
+    let filePath = path.join("src", "testutils", "testwallets", name);
+
+    if (isBrowser()) {
+        return await downloadTextFile(filePath);
+    }
+
     return await fs.promises.readFile(filePath, { encoding: "utf8" });
+}
+
+async function downloadTextFile(url: string) {
+    let response = await axios.get(url, { responseType: "text", transformResponse: []});
+    let text = response.data.toString();
+    return text;
 }
 
 export class TestWallet {

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -6,7 +6,7 @@ import { Address } from "../address";
 import { IProvider, ISigner } from "../interface";
 import { UserSecretKey } from "../walletcore";
 import { UserSigner } from "../walletcore/userSigner";
-import { isBrowser } from "./utils";
+import { isOnBrowserTests } from "./utils";
 
 export async function loadAndSyncTestWallets(provider: IProvider): Promise<Record<string, TestWallet>> {
     let wallets = await loadTestWallets();
@@ -50,7 +50,7 @@ export async function loadTestWallet(name: string): Promise<TestWallet> {
 async function readTestWalletFileContents(name: string): Promise<string> {
     let filePath = path.join("src", "testutils", "testwallets", name);
 
-    if (isBrowser()) {
+    if (isOnBrowserTests()) {
         return await downloadTextFile(filePath);
     }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -23,8 +23,6 @@ import { Hash } from "./hash";
 
 const createTransactionHasher = require("blake2b");
 
-const DEFAULT_TRANSACTION_VERSION = TransactionVersion.withDefaultVersion();
-const DEFAULT_TRANSACTION_OPTIONS = TransactionOptions.withDefaultOptions();
 const TRANSACTION_HASH_LENGTH = 32;
 
 /**
@@ -145,8 +143,8 @@ export class Transaction implements ISignable {
     this.gasLimit = gasLimit || NetworkConfig.getDefault().MinGasLimit;
     this.data = data || new TransactionPayload();
     this.chainID = chainID || NetworkConfig.getDefault().ChainID;
-    this.version = version || DEFAULT_TRANSACTION_VERSION;
-    this.options = options || DEFAULT_TRANSACTION_OPTIONS;
+    this.version = version || TransactionVersion.withDefaultVersion();
+    this.options = options || TransactionOptions.withDefaultOptions();
 
     this.signature = Signature.empty();
     this.hash = TransactionHash.empty();


### PR DESCRIPTION
**1)** Work around problematic imports (causing error in browser tests - `TransactionVersion is undefined`):

Details:
```
index.ts:
	...
	export * from "./transaction";
	...
	export * from "./networkConfig";
	...
	export * from "./networkParams";
	...

transaction.ts:
	import {
	  ...
	  TransactionOptions,
	  TransactionVersion,
	} from "./networkParams";

	const DEFAULT_TRANSACTION_OPTIONS = TransactionOptions.withDefaultOptions();
	const DEFAULT_TRANSACTION_VERSION = TransactionVersion.withDefaultVersion();

networkParams.ts:
	import { NetworkConfig } from "./networkConfig";
networkConfig.ts:
	import { GasPrice, GasLimit, TransactionVersion, ChainID, GasPriceModifier } from "./networkParams";
```

**2)** Load test wallets in browser-tests as well (see `downloadTextFile()`).

**3)** Add a new (unrelated) unit test (for balance builder).

**4)**  Skip some tests in browser: wallet provider tests (they work by mutating a "dummy" global window object) & the ones relying on contract wrappers (they can only be loaded from files, not downloaded from URLs).

**Notes for review:**
- In order to run the browser tests, `npm run browser-tests` and pick the first choice on the page (when it appears).
- https://mochajs.org/#inclusive-tests (also see the paragraph saying that _before/after hooks are skipped unless they are defined at the same level as the hook containing `this.skip()`_).