### PR TITLE
ABI - arrays of known length (array20, array32 etc.)

### DIFF
--- a/src/smartcontracts/codec/arrayVec.ts
+++ b/src/smartcontracts/codec/arrayVec.ts
@@ -1,0 +1,46 @@
+import { TypedValue, ArrayVec, ArrayVecType } from "../typesystem";
+import { BinaryCodec } from "./binary";
+
+export class ArrayVecBinaryCodec {
+    private readonly binaryCodec: BinaryCodec;
+
+    constructor(binaryCodec: BinaryCodec) {
+        this.binaryCodec = binaryCodec;
+    }
+
+    decodeNested(buffer: Buffer, type: ArrayVecType): [ArrayVec, number] {
+        let arrayLength = type.length;
+        let typeParameter = type.getFirstTypeParameter();
+        let result: TypedValue[] = [];
+        let totalLength = 0;
+
+        for (let i = 0; i < arrayLength; i++) {
+            let [decoded, decodedLength] = this.binaryCodec.decodeNested(buffer, typeParameter);
+            result.push(decoded);
+            totalLength += decodedLength;
+            buffer = buffer.slice(decodedLength);
+        }
+
+        return [new ArrayVec(type, result), totalLength];
+    }
+
+    decodeTopLevel(buffer: Buffer, type: ArrayVecType): ArrayVec {
+        let [result, _] = this.decodeNested(buffer, type);
+        return result;
+    }
+
+    encodeNested(array: ArrayVec): Buffer {
+        let itemsBuffers: Buffer[] = [];
+
+        for (const item of array.getItems()) {
+            let itemBuffer = this.binaryCodec.encodeNested(item);
+            itemsBuffers.push(itemBuffer);
+        }
+
+        return Buffer.concat(itemsBuffers);
+    }
+
+    encodeTopLevel(array: ArrayVec): Buffer {
+        return this.encodeNested(array);
+    }
+}

--- a/src/smartcontracts/codec/binary.ts
+++ b/src/smartcontracts/codec/binary.ts
@@ -14,6 +14,8 @@ import {
     EnumValue,
     TupleType,
     Tuple,
+    ArrayVecType,
+    ArrayVec,
 } from "../typesystem";
 import { guardTrue, guardType } from "../../utils";
 import { OptionValueBinaryCodec } from "./option";
@@ -22,11 +24,13 @@ import { ListBinaryCodec } from "./list";
 import { StructBinaryCodec } from "./struct";
 import { EnumBinaryCodec } from "./enum";
 import { TupleBinaryCodec } from "./tuple";
+import { ArrayVecBinaryCodec } from "./arrayVec";
 
 export class BinaryCodec {
     readonly constraints: BinaryCodecConstraints;
     private readonly optionCodec: OptionValueBinaryCodec;
     private readonly listCodec: ListBinaryCodec;
+    private readonly arrayCodec: ArrayVecBinaryCodec;
     private readonly primitiveCodec: PrimitiveBinaryCodec;
     private readonly structCodec: StructBinaryCodec;
     private readonly tupleCodec: TupleBinaryCodec;
@@ -36,6 +40,7 @@ export class BinaryCodec {
         this.constraints = constraints || new BinaryCodecConstraints();
         this.optionCodec = new OptionValueBinaryCodec(this);
         this.listCodec = new ListBinaryCodec(this);
+        this.arrayCodec = new ArrayVecBinaryCodec(this);
         this.primitiveCodec = new PrimitiveBinaryCodec(this);
         this.structCodec = new StructBinaryCodec(this);
         this.tupleCodec = new TupleBinaryCodec(this);
@@ -48,6 +53,7 @@ export class BinaryCodec {
         let typedValue = onTypeSelect<TypedValue>(type, {
             onOption: () => this.optionCodec.decodeTopLevel(buffer, type.getFirstTypeParameter()),
             onList: () => this.listCodec.decodeTopLevel(buffer, type),
+            onArray: () => this.arrayCodec.decodeTopLevel(buffer, <ArrayVecType>type),
             onPrimitive: () => this.primitiveCodec.decodeTopLevel(buffer, <PrimitiveType>type),
             onStruct: () => this.structCodec.decodeTopLevel(buffer, <StructType>type),
             onTuple: () => this.tupleCodec.decodeTopLevel(buffer, <TupleType>type),
@@ -63,6 +69,7 @@ export class BinaryCodec {
         let [typedResult, decodedLength] = onTypeSelect<[TypedValue, number]>(type, {
             onOption: () => this.optionCodec.decodeNested(buffer, type.getFirstTypeParameter()),
             onList: () => this.listCodec.decodeNested(buffer, type),
+            onArray: () => this.arrayCodec.decodeNested(buffer, <ArrayVecType>type),
             onPrimitive: () => this.primitiveCodec.decodeNested(buffer, <PrimitiveType>type),
             onStruct: () => this.structCodec.decodeNested(buffer, <StructType>type),
             onTuple: () => this.tupleCodec.decodeNested(buffer, <TupleType>type),
@@ -85,6 +92,7 @@ export class BinaryCodec {
             onPrimitive: () => this.primitiveCodec.encodeNested(<PrimitiveValue>typedValue),
             onOption: () => this.optionCodec.encodeNested(<OptionValue>typedValue),
             onList: () => this.listCodec.encodeNested(<List>typedValue),
+            onArray: () => this.arrayCodec.encodeNested(<ArrayVec>typedValue),
             onStruct: () => this.structCodec.encodeNested(<Struct>typedValue),
             onTuple: () => this.tupleCodec.encodeNested(<Tuple>typedValue),
             onEnum: () => this.enumCodec.encodeNested(<EnumValue>typedValue),
@@ -105,6 +113,7 @@ export class BinaryCodec {
             onPrimitive: () => this.primitiveCodec.encodeTopLevel(<PrimitiveValue>typedValue),
             onOption: () => this.optionCodec.encodeTopLevel(<OptionValue>typedValue),
             onList: () => this.listCodec.encodeTopLevel(<List>typedValue),
+            onArray: () => this.arrayCodec.encodeTopLevel(<ArrayVec>typedValue),
             onStruct: () => this.structCodec.encodeTopLevel(<Struct>typedValue),
             onTuple: () => this.tupleCodec.encodeTopLevel(<Tuple>typedValue),
             onEnum: () => this.enumCodec.encodeTopLevel(<EnumValue>typedValue),

--- a/src/smartcontracts/typesystem/abiRegistry.spec.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.spec.ts
@@ -86,9 +86,9 @@ describe("test abi registry", () => {
         assert.equal(performAction.output[0].type.getName(), "Action");
 
         let result = bc.decodeTopLevel(buff, performAction.output[0].type);
-        assert.equal(
-            JSON.stringify(result),
-            `{"type":{"name":"Action","typeParameters":[]},"fields":[{"value":{"type":{"name":"CallActionData","typeParameters":[]},"fields":[{"value":{"type":{"name":"Address","typeParameters":[]},"value":{"bech32":"erd13rrn3fwjds8r5260n6q3pd2qa6wqkudrhczh26d957c0edyzermshds0k8","pubkey":"88c738a5d26c0e3a2b4f9e8110b540ee9c0b71a3be057569a5a7b0fcb482c8f7"}},"name":"to"},{"value":{"type":{"name":"BigUint","typeParameters":[]},"value":"500000000000000000","sizeInBytes":0,"withSign":false},"name":"egld_amount"},{"value":{"type":{"name":"bytes","typeParameters":[]},"value":{"type":"Buffer","data":[104,101,108,108,111,32,119,111,114,108,100]}},"name":"endpoint_name"},{"value":{"type":{"name":"List","typeParameters":[{"name":"bytes","typeParameters":[]}]},"items":[]},"name":"arguments"}]},"name":"0"}],"name":"SendTransferExecute","discriminant":5}`
+        assert.deepEqual(
+            JSON.stringify(result.valueOf()),
+            `{"name":"SendTransferExecute","fields":[{"to":{"bech32":"erd13rrn3fwjds8r5260n6q3pd2qa6wqkudrhczh26d957c0edyzermshds0k8","pubkey":"88c738a5d26c0e3a2b4f9e8110b540ee9c0b71a3be057569a5a7b0fcb482c8f7"},"egld_amount":"500000000000000000","endpoint_name":{"type":"Buffer","data":[104,101,108,108,111,32,119,111,114,108,100]},"arguments":[]}]}`
         );
         assert.equal(result.valueOf().name, "SendTransferExecute");
     });

--- a/src/smartcontracts/typesystem/collections.ts
+++ b/src/smartcontracts/typesystem/collections.ts
@@ -1,0 +1,38 @@
+import { TypedValue } from "./types";
+
+export class CollectionOfTypedValues {
+    private readonly items: TypedValue[];
+
+    constructor(items: TypedValue[]) {
+        this.items = items;
+    }
+
+    getLength(): number {
+        return this.items.length;
+    }
+
+    getItems(): ReadonlyArray<TypedValue> {
+        return this.items;
+    }
+
+    valueOf(): any[] {
+        return this.items.map((item) => item.valueOf());
+    }
+
+    equals(other: CollectionOfTypedValues): boolean {
+        if (this.getLength() != other.getLength()) {
+            return false;
+        }
+
+        for (let i = 0; i < this.getLength(); i++) {
+            let selfItem = this.items[i];
+            let otherItem = other.items[i];
+
+            if (!selfItem.equals(otherItem)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/smartcontracts/typesystem/generic.ts
+++ b/src/smartcontracts/typesystem/generic.ts
@@ -1,4 +1,5 @@
 import { guardValueIsSet } from "../../utils";
+import { CollectionOfTypedValues } from "./collections";
 import { Type, TypedValue, NullType, TypePlaceholder } from "./types";
 
 // TODO: Move to a new file, "genericOption.ts"
@@ -79,7 +80,7 @@ export class OptionValue extends TypedValue {
 // TODO: Rename to ListValue, for consistency (though the term is slighly unfortunate).
 // Question for review: or not?
 export class List extends TypedValue {
-    private readonly items: TypedValue[];
+    private readonly backingCollection: CollectionOfTypedValues;
 
     /**
      *
@@ -91,7 +92,7 @@ export class List extends TypedValue {
 
         // TODO: assert items are of type type.getFirstTypeParameter()
 
-        this.items = items;
+        this.backingCollection = new CollectionOfTypedValues(items);
     }
 
     static fromItems(items: TypedValue[]): List {
@@ -105,31 +106,18 @@ export class List extends TypedValue {
     }
 
     getLength(): number {
-        return this.items.length;
+        return this.backingCollection.getLength();
     }
 
     getItems(): ReadonlyArray<TypedValue> {
-        return this.items;
+        return this.backingCollection.getItems();
     }
 
     valueOf(): any[] {
-        return this.items.map((item) => item.valueOf());
+        return this.backingCollection.valueOf();
     }
 
     equals(other: List): boolean {
-        if (this.getLength() != other.getLength()) {
-            return false;
-        }
-
-        for (let i = 0; i < this.getLength(); i++) {
-            let selfItem = this.items[i];
-            let otherItem = other.items[i];
-
-            if (!selfItem.equals(otherItem)) {
-                return false;
-            }
-        }
-
-        return true;
+        return this.backingCollection.equals(other.backingCollection);
     }
 }

--- a/src/smartcontracts/typesystem/generic.ts
+++ b/src/smartcontracts/typesystem/generic.ts
@@ -1,6 +1,7 @@
 import { guardValueIsSet } from "../../utils";
 import { Type, TypedValue, NullType, TypePlaceholder } from "./types";
 
+// TODO: Move to a new file, "genericOption.ts"
 export class OptionType extends Type {
     constructor(typeParameter: Type) {
         super("Option", [typeParameter]);
@@ -17,12 +18,14 @@ export class OptionType extends Type {
     }
 }
 
+// TODO: Move to a new file, "genericList.ts"
 export class ListType extends Type {
     constructor(typeParameter: Type) {
         super("List", [typeParameter]);
     }
 }
 
+// TODO: Move to a new file, "genericOption.ts"
 export class OptionValue extends TypedValue {
     private readonly value: TypedValue | null;
 
@@ -72,6 +75,7 @@ export class OptionValue extends TypedValue {
     }
 }
 
+// TODO: Move to a new file, "genericList.ts"
 // TODO: Rename to ListValue, for consistency (though the term is slighly unfortunate).
 // Question for review: or not?
 export class List extends TypedValue {
@@ -96,7 +100,8 @@ export class List extends TypedValue {
         }
 
         let typeParameter = items[0].getType();
-        return new List(typeParameter, items);
+        let listType = new ListType(typeParameter);
+        return new List(listType, items);
     }
 
     getLength(): number {

--- a/src/smartcontracts/typesystem/genericArray.ts
+++ b/src/smartcontracts/typesystem/genericArray.ts
@@ -1,7 +1,7 @@
 import { guardLength, guardTrue, guardValueIsSet } from "../..";
 import { Type, TypedValue, TypePlaceholder } from "./types";
 
-// A type for fixed-length arrays. E.g. "array20", "array32", "array64" etc.
+// A type for known-length arrays. E.g. "array20", "array32", "array64" etc.
 export class ArrayVecType extends Type {
     readonly length: number;
 
@@ -10,24 +10,6 @@ export class ArrayVecType extends Type {
 
         guardTrue(length > 0, "array length > 0");
         this.length = length;
-    }
-}
-
-export class Array20 extends ArrayVecType {
-    constructor(typeParameter: Type) {
-        super(20, typeParameter);
-    }
-}
-
-export class Array32 extends ArrayVecType {
-    constructor(typeParameter: Type) {
-        super(32, typeParameter);
-    }
-}
-
-export class Array64 extends ArrayVecType {
-    constructor(typeParameter: Type) {
-        super(64, typeParameter);
     }
 }
 

--- a/src/smartcontracts/typesystem/genericArray.ts
+++ b/src/smartcontracts/typesystem/genericArray.ts
@@ -1,5 +1,6 @@
-import { guardLength, guardTrue, guardValueIsSet } from "../..";
-import { Type, TypedValue, TypePlaceholder } from "./types";
+import { guardLength, guardTrue } from "../..";
+import { CollectionOfTypedValues } from "./collections";
+import { Type, TypedValue } from "./types";
 
 // A type for known-length arrays. E.g. "array20", "array32", "array64" etc.
 export class ArrayVecType extends Type {
@@ -14,42 +15,27 @@ export class ArrayVecType extends Type {
 }
 
 export class ArrayVec extends TypedValue {
-    private readonly items: TypedValue[];
+    private readonly backingCollection: CollectionOfTypedValues;
 
     constructor(type: ArrayVecType, items: TypedValue[]) {
         super(type);
-
         guardLength(items, type.length);
-
-        this.items = items;
+        this.backingCollection = new CollectionOfTypedValues(items);
     }
 
     getLength(): number {
-        return this.items.length;
+        return this.backingCollection.getLength();
     }
 
     getItems(): ReadonlyArray<TypedValue> {
-        return this.items;
+        return this.backingCollection.getItems();
     }
 
     valueOf(): any[] {
-        return this.items.map((item) => item.valueOf());
+        return this.backingCollection.valueOf();
     }
 
     equals(other: ArrayVec): boolean {
-        if (this.getLength() != other.getLength()) {
-            return false;
-        }
-
-        for (let i = 0; i < this.getLength(); i++) {
-            let selfItem = this.items[i];
-            let otherItem = other.items[i];
-
-            if (!selfItem.equals(otherItem)) {
-                return false;
-            }
-        }
-
-        return true;
+        return this.backingCollection.equals(other.backingCollection);
     }
 }

--- a/src/smartcontracts/typesystem/genericArray.ts
+++ b/src/smartcontracts/typesystem/genericArray.ts
@@ -1,0 +1,73 @@
+import { guardLength, guardTrue, guardValueIsSet } from "../..";
+import { Type, TypedValue, TypePlaceholder } from "./types";
+
+// A type for fixed-length arrays. E.g. "array20", "array32", "array64" etc.
+export class ArrayVecType extends Type {
+    readonly length: number;
+
+    constructor(length: number, typeParameter: Type) {
+        super("Array", [typeParameter]);
+
+        guardTrue(length > 0, "array length > 0");
+        this.length = length;
+    }
+}
+
+export class Array20 extends ArrayVecType {
+    constructor(typeParameter: Type) {
+        super(20, typeParameter);
+    }
+}
+
+export class Array32 extends ArrayVecType {
+    constructor(typeParameter: Type) {
+        super(32, typeParameter);
+    }
+}
+
+export class Array64 extends ArrayVecType {
+    constructor(typeParameter: Type) {
+        super(64, typeParameter);
+    }
+}
+
+export class ArrayVec extends TypedValue {
+    private readonly items: TypedValue[];
+
+    constructor(type: ArrayVecType, items: TypedValue[]) {
+        super(type);
+
+        guardLength(items, type.length);
+
+        this.items = items;
+    }
+
+    getLength(): number {
+        return this.items.length;
+    }
+
+    getItems(): ReadonlyArray<TypedValue> {
+        return this.items;
+    }
+
+    valueOf(): any[] {
+        return this.items.map((item) => item.valueOf());
+    }
+
+    equals(other: ArrayVec): boolean {
+        if (this.getLength() != other.getLength()) {
+            return false;
+        }
+
+        for (let i = 0; i < this.getLength(); i++) {
+            let selfItem = this.items[i];
+            let otherItem = other.items[i];
+
+            if (!selfItem.equals(otherItem)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/smartcontracts/typesystem/index.ts
+++ b/src/smartcontracts/typesystem/index.ts
@@ -14,6 +14,7 @@ export * from "./endpoint";
 export * from "./enum";
 export * from "./fields";
 export * from "./generic";
+export * from "./genericArray";
 export * from "./h256";
 export * from "./matchers";
 export * from "./nothing";

--- a/src/smartcontracts/typesystem/matchers.ts
+++ b/src/smartcontracts/typesystem/matchers.ts
@@ -11,6 +11,7 @@ import { Struct, StructType } from "./struct";
 import { TokenIdentifierType, TokenIdentifierValue } from "./tokenIdentifier";
 import { Tuple, TupleType } from "./tuple";
 import { Type, PrimitiveType, PrimitiveValue } from "./types";
+import { ArrayVec, ArrayVecType } from "./genericArray";
 
 // TODO: Extend functionality or rename wrt. restricted / reduced functionality (not all types are handled: composite, variadic).
 export function onTypeSelect<TResult>(
@@ -18,6 +19,7 @@ export function onTypeSelect<TResult>(
     selectors: {
         onOption: () => TResult;
         onList: () => TResult;
+        onArray: () => TResult;
         onPrimitive: () => TResult;
         onStruct: () => TResult;
         onTuple: () => TResult;
@@ -30,6 +32,9 @@ export function onTypeSelect<TResult>(
     }
     if (type instanceof ListType) {
         return selectors.onList();
+    }
+    if (type instanceof ArrayVecType) {
+        return selectors.onArray();
     }
     if (type instanceof PrimitiveType) {
         return selectors.onPrimitive();
@@ -57,6 +62,7 @@ export function onTypedValueSelect<TResult>(
         onPrimitive: () => TResult;
         onOption: () => TResult;
         onList: () => TResult;
+        onArray: () => TResult;
         onStruct: () => TResult;
         onTuple: () => TResult;
         onEnum: () => TResult;
@@ -71,6 +77,9 @@ export function onTypedValueSelect<TResult>(
     }
     if (value instanceof List) {
         return selectors.onList();
+    }
+    if (value instanceof ArrayVec) {
+        return selectors.onArray();
     }
     if (value instanceof Struct) {
         return selectors.onStruct();

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -27,6 +27,7 @@ import { OptionalType } from "./algebraic";
 import { StringType, TupleType } from ".";
 import { CodeMetadataType } from "./codeMetadata";
 import { NothingType } from "./nothing";
+import { Array20, Array32, Array64 } from "./genericArray";
 
 type TypeConstructor = new (...typeParameters: Type[]) => Type;
 
@@ -58,6 +59,9 @@ export class TypeMapper {
             ["tuple6", TupleType],
             ["tuple7", TupleType],
             ["tuple8", TupleType],
+            ["array20", Array20],
+            ["array32", Array32],
+            ["array64", Array64],
         ]);
 
         // For closed types, we hold actual type instances instead of type constructors (no type parameters needed).

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -24,47 +24,49 @@ import { TokenIdentifierType } from "./tokenIdentifier";
 import { Type, CustomType } from "./types";
 import { VariadicType } from "./variadic";
 import { OptionalType } from "./algebraic";
-import { StringType, TupleType } from ".";
+import { ArrayVecType } from "./genericArray";
+import { StringType } from "./string";
+import { TupleType } from "./tuple";
 import { CodeMetadataType } from "./codeMetadata";
 import { NothingType } from "./nothing";
-import { Array20, Array32, Array64 } from "./genericArray";
 
-type TypeConstructor = new (...typeParameters: Type[]) => Type;
+type TypeFactory = (...typeParameters: Type[]) => Type;
 
 export class TypeMapper {
-    private readonly openTypesConstructors: Map<string, TypeConstructor>;
+    private readonly openTypesFactories: Map<string, TypeFactory>;
     private readonly closedTypesMap: Map<string, Type>;
 
     constructor(customTypes: CustomType[] = []) {
-        this.openTypesConstructors = new Map<string, TypeConstructor>([
-            ["Option", OptionType],
-            ["List", ListType],
+        this.openTypesFactories = new Map<string, TypeFactory>([
+            ["Option", (...typeParameters: Type[]) => new OptionType(typeParameters[0])],
+            ["List", (...typeParameters: Type[]) => new ListType(typeParameters[0])],
             // For the following open generics, we use a slightly different typing than the one defined by elrond-wasm-rs (temporary workaround).
-            ["VarArgs", VariadicType],
-            ["MultiResultVec", VariadicType],
-            ["variadic", VariadicType],
-            ["OptionalArg", OptionalType],
-            ["optional", OptionalType],
-            ["OptionalResult", OptionalType],
-            ["multi", CompositeType],
-            ["MultiArg", CompositeType],
-            ["MultiResult", CompositeType],
-            ["multi", CompositeType],
+            ["VarArgs", (...typeParameters: Type[]) => new VariadicType(typeParameters[0])],
+            ["MultiResultVec", (...typeParameters: Type[]) => new VariadicType(typeParameters[0])],
+            ["variadic", (...typeParameters: Type[]) => new VariadicType(typeParameters[0])],
+            ["OptionalArg", (...typeParameters: Type[]) => new OptionalType(typeParameters[0])],
+            ["optional", (...typeParameters: Type[]) => new OptionalType(typeParameters[0])],
+            ["OptionalResult", (...typeParameters: Type[]) => new OptionalType(typeParameters[0])],
+            ["multi", (...typeParameters: Type[]) => new CompositeType(...typeParameters)],
+            ["MultiArg", (...typeParameters: Type[]) => new CompositeType(...typeParameters)],
+            ["MultiResult", (...typeParameters: Type[]) => new CompositeType(...typeParameters)],
+            ["multi", (...typeParameters: Type[]) => new CompositeType(...typeParameters)],
             // Perhaps we can adjust the ABI generator to only output "tuple", instead of "tupleN"?
-            ["tuple", TupleType],
-            ["tuple2", TupleType],
-            ["tuple3", TupleType],
-            ["tuple4", TupleType],
-            ["tuple5", TupleType],
-            ["tuple6", TupleType],
-            ["tuple7", TupleType],
-            ["tuple8", TupleType],
-            ["array20", Array20],
-            ["array32", Array32],
-            ["array64", Array64],
+            ["tuple", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
+            ["tuple2", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
+            ["tuple3", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
+            ["tuple4", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
+            ["tuple5", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
+            ["tuple6", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
+            ["tuple7", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
+            ["tuple8", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
+            // Known-length arrays.
+            ["array20", (...typeParameters: Type[]) => new ArrayVecType(20, typeParameters[0])],
+            ["array32", (...typeParameters: Type[]) => new ArrayVecType(32, typeParameters[0])],
+            ["array64", (...typeParameters: Type[]) => new ArrayVecType(64, typeParameters[0])],
         ]);
 
-        // For closed types, we hold actual type instances instead of type constructors (no type parameters needed).
+        // For closed types, we hold actual type instances instead of type constructors / factories (no type parameters needed).
         this.closedTypesMap = new Map<string, Type>([
             ["u8", new U8Type()],
             ["u16", new U16Type()],
@@ -154,11 +156,11 @@ export class TypeMapper {
         let typeParameters = type.getTypeParameters();
         let mappedTypeParameters = typeParameters.map((item) => this.mapType(item));
 
-        let constructor = this.openTypesConstructors.get(type.getName());
-        if (!constructor) {
+        let factory = this.openTypesFactories.get(type.getName());
+        if (!factory) {
             throw new errors.ErrTypingSystem(`Cannot map the generic type "${type.getName()}" to a known type`);
         }
 
-        return new constructor(...mappedTypeParameters);
+        return factory(...mappedTypeParameters);
     }
 }

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -61,6 +61,7 @@ export class TypeMapper {
             ["tuple7", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
             ["tuple8", (...typeParameters: Type[]) => new TupleType(...typeParameters)],
             // Known-length arrays.
+            // TODO: Handle these in typeExpressionParser, perhaps?
             ["array20", (...typeParameters: Type[]) => new ArrayVecType(20, typeParameters[0])],
             ["array32", (...typeParameters: Type[]) => new ArrayVecType(32, typeParameters[0])],
             ["array64", (...typeParameters: Type[]) => new ArrayVecType(64, typeParameters[0])],


### PR DESCRIPTION
 - Implementation for `ArrayVec` is similar to the one for `List` (extracted a bit of commonality to `collections.ts`).
 - In `typeMapper.ts`, for open types, we now use type factories instead of type constructors. This allows us to parametrize (in other ways than just providing the type parameters) the construction of an open type (we needed this for `ArrayVecType`).
 - Left some TODOs (will be done in future PRs).
 - Bugfix on `List.fromItems()` (we don't have a test on this yet).