### PR TITLE
Fix recursivity issue when mapping types

### DIFF
--- a/src/smartcontracts/abi.ts
+++ b/src/smartcontracts/abi.ts
@@ -1,6 +1,6 @@
 import { ErrInvariantFailed } from "../errors";
 import { loadAbiRegistry } from "../testutils";
-import { guardValueIsSet } from "../utils";
+import { guardValueIsSetWithMessage } from "../utils";
 import { ContractFunction } from "./function";
 import { AbiRegistry, EndpointDefinition } from "./typesystem";
 import { ContractInterface } from "./typesystem/contractInterface";
@@ -33,7 +33,7 @@ export class SmartContractAbi {
             name = name.name;
         }
         let result = this.getAllEndpoints().find(item => item.name === name);
-        guardValueIsSet("result", result);
+        guardValueIsSetWithMessage(`endpoint [${name}] not found`, result);
         return result!;
     }
 

--- a/src/smartcontracts/typesystem/contractInterface.ts
+++ b/src/smartcontracts/typesystem/contractInterface.ts
@@ -1,4 +1,4 @@
-import { guardValueIsSet } from "../../utils";
+import { guardValueIsSetWithMessage } from "../../utils";
 import { EndpointDefinition } from "./endpoint";
 
 const NamePlaceholder = "?";
@@ -32,7 +32,7 @@ export class ContractInterface {
 
     getEndpoint(name: string): EndpointDefinition {
         let result = this.endpoints.find(e => e.name == name);
-        guardValueIsSet("result", result);
+        guardValueIsSetWithMessage(`endpoint [${name}] not found`, result);
         return result!;
     }
 }

--- a/src/smartcontracts/typesystem/typeMapper.spec.ts
+++ b/src/smartcontracts/typesystem/typeMapper.spec.ts
@@ -10,59 +10,61 @@ import { OptionalType } from "./algebraic";
 import { CompositeType } from "./composite";
 import { ListType, OptionType } from "./generic";
 import { TupleType } from "./tuple";
+import { TokenIdentifierType } from "..";
 
 type TypeConstructor = new (...typeParameters: Type[]) => Type;
 
 describe("test mapper", () => {
-  let parser = new TypeExpressionParser();
-  let mapper = new TypeMapper();
+    let parser = new TypeExpressionParser();
+    let mapper = new TypeMapper();
 
-  it("should map primitive types", () => {
-    testMapping("u8", U8Type);
-    testMapping("u16", U16Type);
-    testMapping("u32", U32Type);
-    testMapping("u64", U64Type);
-    testMapping("BigUint", BigUIntType);
-  });
+    it("should map primitive types", () => {
+        testMapping("u8", U8Type);
+        testMapping("u16", U16Type);
+        testMapping("u32", U32Type);
+        testMapping("u64", U64Type);
+        testMapping("BigUint", BigUIntType);
+        testMapping("TokenIdentifier", TokenIdentifierType);
+    });
 
-  it("should map generic types", () => {
-    testMapping("Option<u64>", OptionType, [new U64Type()]);
-    testMapping("List<u64>", ListType, [new U64Type()]);
-  });
+    it("should map generic types", () => {
+        testMapping("Option<u64>", OptionType, [new U64Type()]);
+        testMapping("List<u64>", ListType, [new U64Type()]);
+    });
 
-  it("should map variadic types", () => {
-    testMapping("VarArgs<u32>", VariadicType, [new U32Type()]);
-    testMapping("VarArgs<bytes>", VariadicType, [new BytesType()]);
-    testMapping("MultiResultVec<u32>", VariadicType, [new U32Type()]);
-    testMapping("MultiResultVec<Address>", VariadicType, [new AddressType()]);
-  });
+    it("should map variadic types", () => {
+        testMapping("VarArgs<u32>", VariadicType, [new U32Type()]);
+        testMapping("VarArgs<bytes>", VariadicType, [new BytesType()]);
+        testMapping("MultiResultVec<u32>", VariadicType, [new U32Type()]);
+        testMapping("MultiResultVec<Address>", VariadicType, [new AddressType()]);
+    });
 
-  it("should map complex generic, composite, variadic types", () => {
-    testMapping("MultiResultVec<MultiResult<i32,bytes,>>", VariadicType, [
-      new CompositeType(new I32Type(), new BytesType()),
-    ]);
-    testMapping("VarArgs<MultiArg<i32,bytes,>>", VariadicType, [new CompositeType(new I32Type(), new BytesType())]);
-    testMapping("OptionalResult<Address>", OptionalType, [new AddressType()]);
-  });
+    it("should map complex generic, composite, variadic types", () => {
+        testMapping("MultiResultVec<MultiResult<i32,bytes,>>", VariadicType, [
+            new CompositeType(new I32Type(), new BytesType()),
+        ]);
+        testMapping("VarArgs<MultiArg<i32,bytes,>>", VariadicType, [new CompositeType(new I32Type(), new BytesType())]);
+        testMapping("OptionalResult<Address>", OptionalType, [new AddressType()]);
+    });
 
-  it("should map tuples", () => {
-    testMapping("tuple2<u32,bytes>", TupleType, [new U32Type(), new BytesType()]);
-    testMapping("tuple2<Address,BigUint>", TupleType, [new AddressType(), new BigUIntType()]);
-    testMapping("tuple3<u32, bytes, u64>", TupleType, [new U32Type(), new BytesType(), new U64Type()]);
-    //TODO: Rewrite serializer to map more complex objects
+    it("should map tuples", () => {
+        testMapping("tuple2<u32,bytes>", TupleType, [new U32Type(), new BytesType()]);
+        testMapping("tuple2<Address,BigUint>", TupleType, [new AddressType(), new BigUIntType()]);
+        testMapping("tuple3<u32, bytes, u64>", TupleType, [new U32Type(), new BytesType(), new U64Type()]);
+        //TODO: Rewrite serializer to map more complex objects
 
-    // After improvement enable the following test
-    // testMapping("tuple2<tuple3<u32, bytes, u64>, Address>", TupleType, [
-    //   new TupleType(new Type("tuple3", [new U32Type(), new BytesType(), new U64Type()])),
-    //   new AddressType(),
-    // ]);
-  });
+        // After improvement enable the following test
+        // testMapping("tuple2<tuple3<u32, bytes, u64>, Address>", TupleType, [
+        //   new TupleType(new Type("tuple3", [new U32Type(), new BytesType(), new U64Type()])),
+        //   new AddressType(),
+        // ]);
+    });
 
-  function testMapping(expression: string, constructor: TypeConstructor, typeParameters: Type[] = []) {
-    let type = parser.parse(expression);
-    let mappedType = mapper.mapType(type);
+    function testMapping(expression: string, constructor: TypeConstructor, typeParameters: Type[] = []) {
+        let type = parser.parse(expression);
+        let mappedType = mapper.mapType(type);
 
-    assert.instanceOf(mappedType, constructor);
-    assert.deepEqual(mappedType, new constructor(...typeParameters));
-  }
+        assert.instanceOf(mappedType, constructor);
+        assert.deepEqual(mappedType, new constructor(...typeParameters));
+    }
 });

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -97,7 +97,7 @@ export class TypeMapper {
         }
     }
 
-    mapType(type: Type): Type {
+    mapRecursiveType(type: Type): Type | null {
         let isGeneric = type.isGenericType();
 
         if (type instanceof EnumType) {
@@ -114,13 +114,21 @@ export class TypeMapper {
             // This will call mapType() recursively, for all the type parameters.
             return this.mapGenericType(type);
         }
+        return null;
+    }
+
+    mapType(type: Type): Type {
+        let mappedType = this.mapRecursiveType(type);
+        if (mappedType !== null) {
+            return mappedType;
+        }
 
         let knownClosedType = this.closedTypesMap.get(type.getName());
         if (!knownClosedType) {
             throw new errors.ErrTypingSystem(`Cannot map the type "${type.getName()}" to a known type`);
         }
 
-        return knownClosedType;
+        return this.mapRecursiveType(knownClosedType) ?? knownClosedType;
     }
 
     feedCustomType(type: Type): void {

--- a/src/testdata/esdt-nft-marketplace.abi.json
+++ b/src/testdata/esdt-nft-marketplace.abi.json
@@ -1,4 +1,21 @@
 {
+    "buildInfo": {
+        "rustc": {
+            "version": "1.59.0-nightly",
+            "commitHash": "399ba6bb377ce02224b57c4d6e127e160fa76b34",
+            "commitDate": "2022-01-03",
+            "channel": "Nightly",
+            "short": "rustc 1.59.0-nightly (399ba6bb3 2022-01-03)"
+        },
+        "contractCrate": {
+            "name": "esdt-nft-marketplace",
+            "version": "0.0.0"
+        },
+        "framework": {
+            "name": "elrond-wasm",
+            "version": "0.25.0"
+        }
+    },
     "name": "EsdtNftMarketplace",
     "constructor": {
         "inputs": [
@@ -12,6 +29,7 @@
     "endpoints": [
         {
             "name": "setCutPercentage",
+            "mutability": "mutable",
             "inputs": [
                 {
                     "name": "new_cut_percentage",
@@ -22,6 +40,7 @@
         },
         {
             "name": "auctionToken",
+            "mutability": "mutable",
             "payableInTokens": [
                 "*"
             ],
@@ -46,16 +65,35 @@
                     "name": "opt_accepted_payment_token_nonce",
                     "type": "optional<u64>",
                     "multi_arg": true
+                },
+                {
+                    "name": "opt_sft_max_one_per_payment",
+                    "type": "optional<bool>",
+                    "multi_arg": true
+                },
+                {
+                    "name": "opt_start_time",
+                    "type": "optional<u64>",
+                    "multi_arg": true
                 }
             ],
-            "outputs": []
+            "outputs": [
+                {
+                    "type": "u64"
+                }
+            ]
         },
         {
             "name": "bid",
+            "mutability": "mutable",
             "payableInTokens": [
                 "*"
             ],
             "inputs": [
+                {
+                    "name": "auction_id",
+                    "type": "u64"
+                },
                 {
                     "name": "nft_type",
                     "type": "TokenIdentifier"
@@ -69,7 +107,26 @@
         },
         {
             "name": "endAuction",
+            "mutability": "mutable",
             "inputs": [
+                {
+                    "name": "auction_id",
+                    "type": "u64"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "buySft",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "*"
+            ],
+            "inputs": [
+                {
+                    "name": "auction_id",
+                    "type": "u64"
+                },
                 {
                     "name": "nft_type",
                     "type": "TokenIdentifier"
@@ -77,33 +134,94 @@
                 {
                     "name": "nft_nonce",
                     "type": "u64"
+                },
+                {
+                    "name": "opt_sft_buy_amount",
+                    "type": "optional<BigUint>",
+                    "multi_arg": true
                 }
             ],
             "outputs": []
         },
         {
             "name": "withdraw",
+            "mutability": "mutable",
             "inputs": [
                 {
-                    "name": "nft_type",
-                    "type": "TokenIdentifier"
-                },
-                {
-                    "name": "nft_nonce",
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
             "outputs": []
         },
         {
-            "name": "isAlreadyUpForAuction",
+            "name": "claimTokens",
+            "mutability": "mutable",
             "inputs": [
                 {
-                    "name": "nft_type",
+                    "name": "token_id",
                     "type": "TokenIdentifier"
                 },
                 {
-                    "name": "nft_nonce",
+                    "name": "token_nonce",
+                    "type": "u64"
+                },
+                {
+                    "name": "claim_destination",
+                    "type": "Address"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "getMarketplaceCutPercentage",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "BigUint"
+                }
+            ]
+        },
+        {
+            "name": "getLastValidAuctionId",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "getClaimableAmount",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "address",
+                    "type": "Address"
+                },
+                {
+                    "name": "token_id",
+                    "type": "TokenIdentifier"
+                },
+                {
+                    "name": "token_nonce",
+                    "type": "u64"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "BigUint"
+                }
+            ]
+        },
+        {
+            "name": "doesAuctionExist",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
@@ -114,136 +232,192 @@
             ]
         },
         {
-            "name": "getPaymentTokenForAuctionedNft",
+            "name": "getAuctionedToken",
+            "mutability": "readonly",
             "inputs": [
                 {
-                    "name": "nft_type",
-                    "type": "TokenIdentifier"
-                },
-                {
-                    "name": "nft_nonce",
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
             "outputs": [
                 {
-                    "type": "Option<EsdtToken>"
+                    "type": "optional<multi<TokenIdentifier,u64,BigUint>>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "getAuctionType",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "auction_id",
+                    "type": "u64"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "AuctionType"
+                }
+            ]
+        },
+        {
+            "name": "getPaymentTokenForAuction",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "auction_id",
+                    "type": "u64"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "optional<multi<TokenIdentifier,u64>>",
+                    "multi_result": true
                 }
             ]
         },
         {
             "name": "getMinMaxBid",
+            "mutability": "readonly",
             "inputs": [
                 {
-                    "name": "nft_type",
-                    "type": "TokenIdentifier"
-                },
-                {
-                    "name": "nft_nonce",
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
             "outputs": [
                 {
-                    "type": "Option<tuple2<BigUint,BigUint>>"
+                    "type": "optional<multi<BigUint,BigUint>>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "getStartTime",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "auction_id",
+                    "type": "u64"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "optional<u64>",
+                    "multi_result": true
                 }
             ]
         },
         {
             "name": "getDeadline",
+            "mutability": "readonly",
             "inputs": [
                 {
-                    "name": "nft_type",
-                    "type": "TokenIdentifier"
-                },
-                {
-                    "name": "nft_nonce",
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
             "outputs": [
                 {
-                    "type": "Option<u64>"
+                    "type": "optional<u64>",
+                    "multi_result": true
                 }
             ]
         },
         {
             "name": "getOriginalOwner",
+            "mutability": "readonly",
             "inputs": [
                 {
-                    "name": "nft_type",
-                    "type": "TokenIdentifier"
-                },
-                {
-                    "name": "nft_nonce",
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
             "outputs": [
                 {
-                    "type": "Option<Address>"
+                    "type": "optional<Address>",
+                    "multi_result": true
                 }
             ]
         },
         {
             "name": "getCurrentWinningBid",
+            "mutability": "readonly",
             "inputs": [
                 {
-                    "name": "nft_type",
-                    "type": "TokenIdentifier"
-                },
-                {
-                    "name": "nft_nonce",
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
             "outputs": [
                 {
-                    "type": "Option<BigUint>"
+                    "type": "optional<BigUint>",
+                    "multi_result": true
                 }
             ]
         },
         {
             "name": "getCurrentWinner",
+            "mutability": "readonly",
             "inputs": [
                 {
-                    "name": "nft_type",
-                    "type": "TokenIdentifier"
-                },
-                {
-                    "name": "nft_nonce",
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
             "outputs": [
                 {
-                    "type": "Option<Address>"
+                    "type": "optional<Address>",
+                    "multi_result": true
                 }
             ]
         },
         {
             "name": "getFullAuctionData",
+            "mutability": "readonly",
             "inputs": [
                 {
-                    "name": "nft_type",
-                    "type": "TokenIdentifier"
-                },
-                {
-                    "name": "nft_nonce",
+                    "name": "auction_id",
                     "type": "u64"
                 }
             ],
             "outputs": [
                 {
-                    "type": "Option<Auction>"
+                    "type": "optional<Auction>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "getAllAuctions",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "List<tuple<u64,Auction>>"
                 }
             ]
         }
     ],
+    "hasCallback": false,
     "types": {
         "Auction": {
             "type": "struct",
             "fields": [
+                {
+                    "name": "auctioned_token",
+                    "type": "EsdtToken"
+                },
+                {
+                    "name": "nr_auctioned_tokens",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "auction_type",
+                    "type": "AuctionType"
+                },
                 {
                     "name": "payment_token",
                     "type": "EsdtToken"
@@ -254,7 +428,11 @@
                 },
                 {
                     "name": "max_bid",
-                    "type": "BigUint"
+                    "type": "Option<BigUint>"
+                },
+                {
+                    "name": "start_time",
+                    "type": "u64"
                 },
                 {
                     "name": "deadline",
@@ -271,6 +449,35 @@
                 {
                     "name": "current_winner",
                     "type": "Address"
+                },
+                {
+                    "name": "marketplace_cut_percentage",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "creator_royalties_percentage",
+                    "type": "BigUint"
+                }
+            ]
+        },
+        "AuctionType": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "None",
+                    "discriminant": 0
+                },
+                {
+                    "name": "Nft",
+                    "discriminant": 1
+                },
+                {
+                    "name": "SftAll",
+                    "discriminant": 2
+                },
+                {
+                    "name": "SftOnePerPayment",
+                    "discriminant": 3
                 }
             ]
         },


### PR DESCRIPTION
This PR fixes `Error: type isn't known: TokenIdentifier` when trying to decode the output of the `getAllAuctions` endpoint.
I added two basic tests for `TokenIdentifier` in `binary.spec.ts` and in `typeMapper.spec.ts`, as I initially thought the issue was with the `TokenIdentifier` type. However, this was not the case. I think it's fine if the tests stay though.
As such, I created a test in `esdt.spec.ts` which uses the data from the original report, decoding the output of the `getAllAuctions` endpoint from pre-defined data. I had to update `esdt-nft-marketplace.abi.json` to the most recent version and add the `getAllAuctions` endpoint description manually.

**The issue explained**
The issue occurs because the `EsdtToken` type is located below the `Auction` type in the json ABI. I confirmed this by running the tests with those types in reversed order, which allows the tests to pass.
After the ABI is loaded the type remapping occurs in `remapToKnownTypes` from `abiRegistry.ts`, which calls `mapType` from `typeMapper.ts` in order to resolve the actual type of the types. As an example, after loading the the json ABI, the object which represents the token identifier type is `new Type("TokenIdentifier", typeParameters)`. Remapping it results re-creates it as `new TokenIdentifierType("TokenIdentifier", typeParameters)`. As a side note, this was also the reason for the ambiguous `Error: type isn't known: TokenIdentifier`, because the check `instanceof PrimitiveType` from `onTypedValueSelect` fails for `Type`, but not for `TokenIdentifier` which inherits from `PrimitiveType`.
The remapping step made the assumption that all the types resulting from `let knownClosedType = this.closedTypesMap.get(type.getName());` are fully resolved, which is not always true if we have a nested structure where the structs are loaded in reverse order. In this case `Auction` contains `EsdtToken`, which contains `TokenIdentifier`. The latter was left unresolved, since the handling was stopping one nesting level short, hence the error.

Also fixed the guard messages when endpoints are not found.