### PR TITLE
Bump version to "9.0.2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [9.0.2]
+ - Bump version, since previously published `8.0.2-alpha.1` version is picked as `latest` version by npmjs.
+
 ## [9.0.1]
 - [Add globals polyfill for Buffer](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/112)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@elrondnetwork/erdjs",
-    "version": "8.0.1-alpha.22",
+    "version": "9.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/erdjs",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Smart Contracts interaction framework",
   "main": "out/index.js",
   "types": "out/index.d.js",


### PR DESCRIPTION
Bump version to "9.0.2", since previously published "8.0.2-alpha.1" version is displayed as "latest" version by npmjs.