### PR TITLE
Sketch logs & events, add extra fields on TransactionOnNetwork, define TokenOfAccountOnNetwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
   - [Fix constructor of `NumericalValue`](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/128).
-  - TBD
+  - [Sketch logs & events, add extra fields on TransactionOnNetwork, define TokenOfAccountOnNetwork](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/129).
 
 ## [9.0.3]
  - [Extension Provider throw error if tx canceled](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/111).

--- a/src/account.ts
+++ b/src/account.ts
@@ -3,6 +3,7 @@ import { Address } from "./address";
 import { Nonce } from "./nonce";
 import { Balance } from "./balance";
 import { Egld } from "./balanceBuilder";
+import BigNumber from "bignumber.js";
 
 /**
  * An abstraction representing an account (user or Smart Contract) on the Network.
@@ -116,6 +117,28 @@ export class AccountOnNetwork {
         result.balance = Balance.fromString(payload["balance"]);
         result.code = payload["code"];
         result.userName = payload["username"];
+
+        return result;
+    }
+}
+
+export class TokenOfAccountOnNetwork {
+    tokenIdentifier: string = "";
+    attributes: Buffer = Buffer.from([]);
+    balance: BigNumber = new BigNumber(0);
+    nonce: Nonce = new Nonce(0);
+    creator: Address = new Address("");
+    royalties: BigNumber = new BigNumber(0);
+
+    static fromHttpResponse(payload: any): TokenOfAccountOnNetwork {
+        let result = new TokenOfAccountOnNetwork();
+
+        result.tokenIdentifier = payload.tokenIdentifier;
+        result.attributes = Buffer.from(payload.attributes || "", "base64");
+        result.balance = new BigNumber(payload.balance || 0);
+        result.nonce = new Nonce(payload.nonce || 0);
+        result.creator = new Address(payload.creator || "");
+        result.royalties = new BigNumber(payload.royalties || 0);
 
         return result;
     }

--- a/src/apiProvider.ts
+++ b/src/apiProvider.ts
@@ -46,7 +46,7 @@ export class ApiProvider implements IApiProvider {
      */
     async getTransaction(txHash: TransactionHash): Promise<TransactionOnNetwork> {
         return this.doGetGeneric(`transactions/${txHash.toString()}`, (response) =>
-            TransactionOnNetwork.fromHttpResponse(response)
+            TransactionOnNetwork.fromHttpResponse(txHash, response)
         );
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -480,3 +480,12 @@ export class ErrInvalidTxSignReturnValue extends Err {
     super("Invalid response in transaction sign return url");
   }
 }
+
+/**
+ * Signals that a specific transaction event was not found (i.e. in the transaction logs).
+ */
+export class ErrTransactionEventNotFound extends Err {
+  public constructor(identifier: string) {
+    super(`Transaction event with identifier [${identifier}] not found (in logs)`);
+  }
+}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,7 +2,7 @@ import { Transaction, TransactionHash, TransactionStatus } from "./transaction";
 import { NetworkConfig } from "./networkConfig";
 import { Signature } from "./signature";
 import { Address } from "./address";
-import { AccountOnNetwork } from "./account";
+import { AccountOnNetwork, TokenOfAccountOnNetwork } from "./account";
 import { Query } from "./smartcontracts";
 import { QueryResponse } from "./smartcontracts";
 import { NetworkStake } from "./networkStake";
@@ -49,7 +49,7 @@ export interface IProvider extends ITransactionFetcher {
     /**
      * Fetches the list of ESDT data for all the tokens of an address.
      */
-    getAddressEsdtList(address: Address): Promise<any>;
+    getAddressEsdtList(address: Address): Promise<TokenOfAccountOnNetwork[]>;
 
     /**
      * Fetches the ESDT data for a token of an address.

--- a/src/proxyProvider.ts
+++ b/src/proxyProvider.ts
@@ -6,7 +6,7 @@ import { Transaction, TransactionHash, TransactionStatus } from "./transaction";
 import { NetworkConfig } from "./networkConfig";
 import { Address } from "./address";
 import * as errors from "./errors";
-import { AccountOnNetwork } from "./account";
+import { AccountOnNetwork, TokenOfAccountOnNetwork } from "./account";
 import { Query } from "./smartcontracts/query";
 import { QueryResponse } from "./smartcontracts/queryResponse";
 import { Logger } from "./logger";
@@ -42,10 +42,11 @@ export class ProxyProvider implements IProvider {
         );
     }
 
-    async getAddressEsdtList(address: Address): Promise<any> {
-        return this.doGetGeneric(`address/${address.bech32()}/esdt`, (response) =>
-            response.esdts
-        );
+    async getAddressEsdtList(address: Address): Promise<TokenOfAccountOnNetwork[]> {
+        let url = `address/${address.bech32()}/esdt`;
+        let raw = await this.doGetGeneric(url, response => response.esdts);
+        let tokens = Object.values(raw).map(item => TokenOfAccountOnNetwork.fromHttpResponse(item));
+        return tokens;
     }
 
     async getAddressEsdt(address: Address, tokenIdentifier: string): Promise<any> {
@@ -105,7 +106,7 @@ export class ProxyProvider implements IProvider {
             withResults: withResults ? "true" : "",
         });
 
-        return this.doGetGeneric(url, (response) => TransactionOnNetwork.fromHttpResponse(response.transaction));
+        return this.doGetGeneric(url, (response) => TransactionOnNetwork.fromHttpResponse(txHash, response.transaction));
     }
 
     /**

--- a/src/token.ts
+++ b/src/token.ts
@@ -10,6 +10,7 @@ export enum TokenType {
 export class Token {
     identifier: string = ''; // Token identifier (ticker + random string, eg. MYTOKEN-12345)
     name: string = ''; // Token name (eg. MyTokenName123)
+    ticker: string = '';
     type: TokenType = TokenType.Fungible;
     owner: Address = new Address();
     supply: string = '0'; // Circulating supply = initial minted supply + local mints - local burns
@@ -34,6 +35,7 @@ export class Token {
     static fromHttpResponse(response: {
         identifier: string,
         name: string,
+        ticker: string,
         type: string,
         owner: string,
         supply: string,
@@ -50,6 +52,7 @@ export class Token {
         return new Token({
             identifier: response.identifier,
             name: response.name,
+            ticker: response.ticker,
             type: TokenType[response.type as keyof typeof TokenType],
             owner: new Address(response.owner),
             supply: response.supply,

--- a/src/transaction.dev.net.spec.ts
+++ b/src/transaction.dev.net.spec.ts
@@ -41,6 +41,7 @@ describe("test transactions on devnet", function () {
         // Ignore fields which are not present on API response:
         transactionOnProxy.epoch = 0;
         transactionOnProxy.type = new TransactionOnNetworkType();
+        transactionOnProxy.blockNonce = new Nonce(0);
         transactionOnProxy.hyperblockNonce = new Nonce(0);
         transactionOnProxy.hyperblockHash = new Hash("");
 

--- a/src/transactionLogs.ts
+++ b/src/transactionLogs.ts
@@ -1,0 +1,71 @@
+import { Address } from ".";
+import { ErrTransactionEventNotFound } from "./errors";
+
+export class TransactionLogs {
+    readonly address: Address;
+    readonly events: TransactionEvent[];
+
+    constructor(address: Address, events: TransactionEvent[]) {
+        this.address = address;
+        this.events = events;
+    }
+
+    static empty(): TransactionLogs {
+        return new TransactionLogs(new Address(), []);
+    }
+
+    static fromHttpResponse(logs: any): TransactionLogs {
+        let address = new Address(logs.address);
+        let events = (logs.events || []).map((event: any) => TransactionEvent.fromHttpResponse(event));
+        return new TransactionLogs(address, events);
+    }
+
+    findEventByIdentifier(identifier: string) {
+        let event = this.events.filter(event => event.identifier == identifier)[0];
+        if (event) {
+            return event;
+        }
+
+        throw new ErrTransactionEventNotFound(identifier);
+    }
+}
+
+export class TransactionEvent {
+    readonly address: Address;
+    readonly identifier: string;
+    readonly topics: TransactionEventTopic[];
+
+    constructor(address: Address, identifier: string, topics: TransactionEventTopic[]) {
+        this.address = address;
+        this.identifier = identifier;
+        this.topics = topics;
+    }
+
+    static fromHttpResponse(responsePart: {
+        address: string,
+        identifier: string,
+        topics: string[]
+    }): TransactionEvent {
+        let topics = (responsePart.topics || []).map(topic => new TransactionEventTopic(topic));
+        let address = new Address(responsePart.address);
+        let identifier = responsePart.identifier || "";
+        let event = new TransactionEvent(address, identifier, topics);
+        return event;
+    }
+}
+
+export class TransactionEventTopic {
+    private readonly raw: Buffer;
+
+    constructor(topic: string) {
+        this.raw = Buffer.from(topic || "", "base64");
+    }
+
+    toString() {
+        return this.raw.toString("utf8");
+    }
+
+    valueOf(): Buffer {
+        return this.raw;
+    }
+}


### PR DESCRIPTION
 - Partially parse transaction logs from the API / Gateway (more functionality in future PRs).
 - Add fields on `TransactionOnNetwork`: `hash`, `timestamp`, `blockNonce`.
 - Add `ticker` field on `Token`.
 - Define `TokenOfAccountOnNetwork` (returned from `ProxyProvider.getAddressEsdtList()`)