### PR TITLE
fix web wallet transaction singing

### DIFF
--- a/src/dapp/walletProvider.spec.ts
+++ b/src/dapp/walletProvider.spec.ts
@@ -69,10 +69,10 @@ describe("test wallet provider", () => {
     });
 
     await walletProvider.sendTransaction(mockTransaction);
-    assert.equal(window.location.href, "http://mocked-wallet.com/hook/transaction?receiver=erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu&value=0&gasLimit=50000&gasPrice=1000000000&callbackUrl=http://return-to-wallet");
+    assert.equal(window.location.href, "http://mocked-wallet.com/hook/transaction?receiver=erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu&value=0&gasLimit=50000&gasPrice=1000000000&nonce=0&callbackUrl=http://return-to-wallet");
 
     await walletProvider.sendTransaction(mockTransaction, {callbackUrl: "http://another-callback"});
-    assert.equal(window.location.href, "http://mocked-wallet.com/hook/transaction?receiver=erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu&value=0&gasLimit=50000&gasPrice=1000000000&callbackUrl=http://another-callback");
+    assert.equal(window.location.href, "http://mocked-wallet.com/hook/transaction?receiver=erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu&value=0&gasLimit=50000&gasPrice=1000000000&nonce=0&callbackUrl=http://another-callback");
   });
 
   it('sign transaction redirects correctly', async () => {
@@ -82,10 +82,10 @@ describe("test wallet provider", () => {
     });
 
     await walletProvider.signTransaction(mockTransaction);
-    assert.equal(window.location.href, "http://mocked-wallet.com/hook/sign?receiver=erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu&value=0&gasLimit=50000&gasPrice=1000000000&callbackUrl=http://return-to-wallet");
+    assert.equal(window.location.href, "http://mocked-wallet.com/hook/sign?receiver=erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu&value=0&gasLimit=50000&gasPrice=1000000000&nonce=0&callbackUrl=http://return-to-wallet");
 
     await walletProvider.signTransaction(mockTransaction, {callbackUrl: "http://another-callback"});
-    assert.equal(window.location.href, "http://mocked-wallet.com/hook/sign?receiver=erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu&value=0&gasLimit=50000&gasPrice=1000000000&callbackUrl=http://another-callback");
+    assert.equal(window.location.href, "http://mocked-wallet.com/hook/sign?receiver=erd1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gq4hu&value=0&gasLimit=50000&gasPrice=1000000000&nonce=0&callbackUrl=http://another-callback");
   });
 
   it('sign multiple transactions redirects correctly', async () => {

--- a/src/dapp/walletProvider.ts
+++ b/src/dapp/walletProvider.ts
@@ -243,7 +243,7 @@ export class WalletProvider implements IDappProvider {
         if (transaction.data) {
             urlString += `&data=${transaction.data}`;
         }
-        if (transaction.nonce) {
+        if (transaction.nonce || transaction.nonce === 0) {
             urlString += `&nonce=${transaction.nonce}`;
         }
 


### PR DESCRIPTION
this PR fixes transaction signing for accounts with nonce 0.

with the current implementation, the web wallet handles requests without nonce (in the query params) by not showing a modal at all.