### PR TITLE
Remove usages of guardType()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
- - TBD
+ - [Fix WalletProvider URL when nonce = 0](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/137)
+ - [Fix padding for getTxFieldsForEsdtTransfer](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/140)
+ - [Added payableBySc to CodeMetadata](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/141)
+ - [Remove usages of guardType()](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/143)
 
 ## [9.1.0]
   - [Interactions: enable token transfers ("transfer with execute")](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/131)

--- a/src/smartcontracts/codec/binary.ts
+++ b/src/smartcontracts/codec/binary.ts
@@ -17,7 +17,7 @@ import {
     ArrayVecType,
     ArrayVec,
 } from "../typesystem";
-import { guardTrue, guardType } from "../../utils";
+import { guardTrue } from "../../utils";
 import { OptionValueBinaryCodec } from "./option";
 import { PrimitiveBinaryCodec } from "./primitive";
 import { ListBinaryCodec } from "./list";
@@ -100,7 +100,6 @@ export class BinaryCodec {
     }
 
     encodeTopLevel(typedValue: TypedValue): Buffer {
-        guardType("value", TypedValue, typedValue, false);
         guardTrue(
             typedValue
                 .getType()

--- a/src/smartcontracts/typesystem/numerical.ts
+++ b/src/smartcontracts/typesystem/numerical.ts
@@ -1,5 +1,4 @@
 import * as errors from "../../errors";
-import { guardType } from "../../utils";
 import { PrimitiveType, PrimitiveValue, Type } from "./types";
 import BigNumber from "bignumber.js";
 
@@ -92,7 +91,6 @@ export class NumericalValue extends PrimitiveValue {
 
     constructor(type: NumericalType, value: BigNumber.Value) {
         super(type);
-        guardType("type", NumericalType, type, false);
 
         this.value = new BigNumber(value);
         this.sizeInBytes = type.sizeInBytes;

--- a/src/transaction.spec.ts
+++ b/src/transaction.spec.ts
@@ -1,34 +1,12 @@
 import { assert } from "chai";
 import { Transaction } from "./transaction";
-import * as errors from "./errors";
 import { Nonce } from "./nonce";
 import { ChainID, GasLimit, GasPrice, GasPriceModifier, TransactionOptions, TransactionVersion } from "./networkParams";
 import { TransactionPayload } from "./transactionPayload";
 import { Balance } from "./balance";
 import { loadTestWallets, TestWallet } from "./testutils";
 import { NetworkConfig } from "./networkConfig";
-import { Address } from "./address";
 
-describe("test transaction", () => {
-    it("should throw error when bad types", () => {
-        assert.throw(() => new Transaction({ nonce: <any>42, receiver: new Address() }), errors.ErrBadType);
-        assert.throw(() => new Transaction({ receiver: new Address(), gasLimit: <any>42 }), errors.ErrBadType);
-        assert.throw(() => new Transaction({ receiver: new Address(), gasPrice: <any>42 }), errors.ErrBadType);
-
-        assert.throw(() => new Transaction({ nonce: <any>7, receiver: new Address() }), errors.ErrBadType);
-        assert.throw(() => new Transaction({ gasLimit: <any>8, receiver: new Address() }), errors.ErrBadType);
-        assert.throw(() => new Transaction({ gasPrice: <any>9, receiver: new Address() }), errors.ErrBadType);
-
-        assert.doesNotThrow(() => new Transaction({ receiver: new Address() }));
-        assert.doesNotThrow(() => new Transaction({
-            nonce: new Nonce(42),
-            gasLimit: new GasLimit(42),
-            gasPrice: new GasPrice(42),
-            receiver: new Address()
-        }));
-        assert.doesNotThrow(() => new Transaction({ nonce: undefined, gasLimit: undefined, gasPrice: undefined, receiver: new Address() }));
-    });
-});
 
 describe("test transaction construction", async () => {
     let wallets: Record<string, TestWallet>;

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -12,7 +12,7 @@ import {
 import { NetworkConfig } from "./networkConfig";
 import { Nonce } from "./nonce";
 import { Signature } from "./signature";
-import { guardEmpty, guardNotEmpty, guardType } from "./utils";
+import { guardEmpty, guardNotEmpty } from "./utils";
 import { TransactionPayload } from "./transactionPayload";
 import * as errors from "./errors";
 import { TypedEvent } from "./events";

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -153,12 +153,6 @@ export class Transaction implements ISignable {
     this.onSent = new TypedEvent();
     this.onStatusUpdated = new TypedEvent();
     this.onStatusChanged = new TypedEvent();
-
-    // We apply runtime type checks for these fields, since they are the most commonly misused when calling the Transaction constructor
-    // in JavaScript (which lacks type safety).
-    guardType("nonce", Nonce, this.nonce);
-    guardType("gasLimit", GasLimit, this.gasLimit);
-    guardType("gasPrice", GasPrice, this.gasPrice);
   }
 
   getNonce(): Nonce {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,17 +8,6 @@ export function guardTrue(value: boolean, what: string) {
     }
 }
 
-export function guardType(name: string, type: any, value?: any, allowUndefined: boolean = true) {
-    if (allowUndefined && value === undefined) {
-        return;
-    }
-    if (value instanceof type) {
-        return;
-    }
-
-    throw new errors.ErrBadType(name, type, value);
-}
-
 // TODO: merge with guardValueIsSetWithMessage
 export function guardValueIsSet(name: string, value?: any | null | undefined) {
     guardValueIsSetWithMessage(`${name} isn't set (null or undefined)`, value);


### PR DESCRIPTION
The usages of `guardType()` are causing some type checks to fail when referencing both _erdjs_ and an _erdjs dependent_ within the same project, when one of them (or both) are referenced using `npm link`.

Before, the reason for using a function such as `guardType()` was:

> We apply runtime type checks for (some) fields, since they are the [...] commonly misused when calling the [...] constructor from JavaScript (which lacks type safety).

However, the developers should use TypeScript instead and have all the benefits of type-checking at compile-time.