### PR TITLE
Remove JavaScript's native instanceof, where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - [Fix padding for getTxFieldsForEsdtTransfer](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/140)
  - [Added payableBySc to CodeMetadata](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/141)
  - [Remove usages of guardType()](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/143)
+ - [Remove JavaScript's native instanceof, where possible](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/145)
 
 ## [9.1.0]
   - [Interactions: enable token transfers ("transfer with execute")](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/131)

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -1,3 +1,7 @@
+export function hasJavascriptConstructor(obj: Object, javascriptConstructorName: string): boolean {
+    return obj.constructor.name == javascriptConstructorName;
+}
+
 export function getJavascriptConstructorsNamesInHierarchy(obj: Object, filter: (prototype: any) => boolean): string[] {
     let prototypes = getJavascriptPrototypesInHierarchy(obj, filter);
     let constructorNames = prototypes.map(prototype => prototype.constructor.name);

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -1,0 +1,17 @@
+export function getJavascriptConstructorsNamesInHierarchy(obj: Object, filter: (prototype: any) => boolean): string[] {
+    let prototypes = getJavascriptPrototypesInHierarchy(obj, filter);
+    let constructorNames = prototypes.map(prototype => prototype.constructor.name);
+    return constructorNames;
+}
+
+export function getJavascriptPrototypesInHierarchy(obj: Object, filter: (prototype: any) => boolean): Object[] {
+    let prototypes: Object[] = [];
+    let prototype: any = Object.getPrototypeOf(obj);
+
+    while (prototype && filter(prototype)) {
+        prototypes.push(prototype);
+        prototype = Object.getPrototypeOf(prototype);
+    }
+
+    return prototypes;
+}

--- a/src/smartcontracts/abi.ts
+++ b/src/smartcontracts/abi.ts
@@ -1,5 +1,4 @@
 import { ErrInvariantFailed } from "../errors";
-import { loadAbiRegistry } from "../testutils";
 import { guardValueIsSetWithMessage } from "../utils";
 import { ContractFunction } from "./function";
 import { AbiRegistry, EndpointDefinition } from "./typesystem";

--- a/src/smartcontracts/argSerializer.ts
+++ b/src/smartcontracts/argSerializer.ts
@@ -52,10 +52,10 @@ export class ArgSerializer {
         function readValue(type: Type): TypedValue {
             // TODO: Use matchers.
 
-            if (type instanceof OptionalType) {
+            if (type.hasJavascriptConstructor(OptionalType.name)) {
                 let typedValue = readValue(type.getFirstTypeParameter());
                 return new OptionalValue(type, typedValue);
-            } else if (type instanceof VariadicType) {
+            } else if (type.hasJavascriptConstructor(VariadicType.name)) {
                 let typedValues = [];
 
                 while (!hasReachedTheEnd()) {
@@ -63,7 +63,7 @@ export class ArgSerializer {
                 }
 
                 return new VariadicValue(type, typedValues);
-            } else if (type instanceof CompositeType) {
+            } else if (type.hasJavascriptConstructor(CompositeType.name)) {
                 let typedValues = [];
 
                 for (const typeParameter of type.getTypeParameters()) {
@@ -132,16 +132,19 @@ export class ArgSerializer {
         function handleValue(value: TypedValue): void {
             // TODO: Use matchers.
 
-            if (value instanceof OptionalValue) {
-                if (value.isSet()) {
-                    handleValue(value.getTypedValue());
+            if (value.hasJavascriptConstructor(OptionalValue.name)) {
+                let valueAsOptional = <OptionalValue>value;
+                if (valueAsOptional.isSet()) {
+                    handleValue(valueAsOptional.getTypedValue());
                 }
-            } else if (value instanceof VariadicValue) {
-                for (const item of value.getItems()) {
+            } else if (value.hasJavascriptConstructor(VariadicValue.name)) {
+                let valueAsVariadic = <VariadicValue>value;
+                for (const item of valueAsVariadic.getItems()) {
                     handleValue(item);
                 }
-            } else if (value instanceof CompositeValue) {
-                for (const item of value.getItems()) {
+            } else if (value.hasJavascriptConstructor(CompositeValue.name)) {
+                let valueAsComposite = <CompositeValue>value;
+                for (const item of valueAsComposite.getItems()) {
                     handleValue(item);
                 }
             } else {

--- a/src/smartcontracts/interaction.local.net.spec.ts
+++ b/src/smartcontracts/interaction.local.net.spec.ts
@@ -127,7 +127,7 @@ describe("test smart contract interactor", function () {
         let { returnCode: statusReturnCode, values: statusReturnValues, firstValue: statusFirstValue } = await runner.runAwaitExecution(lotteryStatusInteraction.withNonce(alice.account.getNonceThenIncrement()))
         assert.isTrue(statusReturnCode.equals(ReturnCode.Ok));
         assert.lengthOf(statusReturnValues, 1);
-        assert.equal(statusFirstValue.valueOf(), "Running");
+        assert.equal(statusFirstValue.valueOf().name, "Running");
 
         // lotteryInfo() (this is a view function, but for the sake of the test, we'll execute it)
         let { returnCode: infoReturnCode, values: infoReturnValues, firstValue: infoFirstValue } = await runner.runAwaitExecution(getLotteryInfoInteraction.withNonce(alice.account.getNonceThenIncrement()))

--- a/src/smartcontracts/typesystem/abiRegistry.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.ts
@@ -76,7 +76,7 @@ export class AbiRegistry {
         return names.map((name) => this.getInterface(name));
     }
     getStruct(name: string): StructType {
-        let result = this.customTypes.find((e) => e.getName() == name && e instanceof StructType);
+        let result = this.customTypes.find((e) => e.getName() == name && e.hasJavascriptConstructor(StructType.name));
         guardValueIsSetWithMessage(`struct [${name}] not found`, result);
         return <StructType>result!;
     }
@@ -84,7 +84,7 @@ export class AbiRegistry {
         return names.map((name) => this.getStruct(name));
     }
     getEnum(name: string): EnumType {
-        let result = this.customTypes.find((e) => e.getName() == name && e instanceof EnumType);
+        let result = this.customTypes.find((e) => e.getName() == name && e.hasJavascriptConstructor(EnumType.name));
         guardValueIsSetWithMessage(`enum [${name}] not found`, result);
         return <EnumType>result!;
     }

--- a/src/smartcontracts/typesystem/generic.ts
+++ b/src/smartcontracts/typesystem/generic.ts
@@ -9,12 +9,12 @@ export class OptionType extends Type {
     }
 
     isAssignableFrom(type: Type): boolean {
-        if (!(type instanceof OptionType)) {
+        if (!(type.hasJavascriptConstructor(OptionType.name))) {
             return false;
         }
 
         let invariantTypeParameters = this.getFirstTypeParameter().equals(type.getFirstTypeParameter());
-        let fakeCovarianceToNull = type.getFirstTypeParameter() instanceof NullType;
+        let fakeCovarianceToNull = type.getFirstTypeParameter().hasJavascriptConstructor(NullType.name);
         return invariantTypeParameters || fakeCovarianceToNull;
     }
 }

--- a/src/smartcontracts/typesystem/matchers.ts
+++ b/src/smartcontracts/typesystem/matchers.ts
@@ -70,25 +70,25 @@ export function onTypedValueSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (value instanceof PrimitiveValue) {
+    if (value.hasConstructorInHierarchy(PrimitiveValue.name)) {
         return selectors.onPrimitive();
     }
-    if (value instanceof OptionValue) {
+    if (value.hasConstructorInHierarchy(OptionValue.name)) {
         return selectors.onOption();
     }
-    if (value instanceof List) {
+    if (value.hasConstructorInHierarchy(List.name)) {
         return selectors.onList();
     }
-    if (value instanceof ArrayVec) {
+    if (value.hasConstructorInHierarchy(ArrayVec.name)) {
         return selectors.onArray();
     }
-    if (value instanceof Struct) {
+    if (value.hasConstructorInHierarchy(Struct.name)) {
         return selectors.onStruct();
     }
-    if (value instanceof Tuple) {
+    if (value.hasConstructorInHierarchy(Tuple.name)) {
         return selectors.onTuple();
     }
-    if (value instanceof EnumValue) {
+    if (value.hasConstructorInHierarchy(EnumValue.name)) {
         return selectors.onEnum();
     }
 
@@ -112,25 +112,25 @@ export function onPrimitiveValueSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (value instanceof BooleanValue) {
+    if (value.hasConstructorInHierarchy(BooleanValue.name)) {
         return selectors.onBoolean();
     }
-    if (value instanceof NumericalValue) {
+    if (value.hasConstructorInHierarchy(NumericalValue.name)) {
         return selectors.onNumerical();
     }
-    if (value instanceof AddressValue) {
+    if (value.hasConstructorInHierarchy(AddressValue.name)) {
         return selectors.onAddress();
     }
-    if (value instanceof BytesValue) {
+    if (value.hasConstructorInHierarchy(BytesValue.name)) {
         return selectors.onBytes();
     }
-    if (value instanceof H256Value) {
+    if (value.hasConstructorInHierarchy(H256Value.name)) {
         return selectors.onH256();
     }
-    if (value instanceof TokenIdentifierValue) {
+    if (value.hasConstructorInHierarchy(TokenIdentifierValue.name)) {
         return selectors.onTypeIdentifier();
     }
-    if (value instanceof NothingValue) {
+    if (value.hasConstructorInHierarchy(NothingValue.name)) {
         return selectors.onNothing();
     }
     if (selectors.onOther) {

--- a/src/smartcontracts/typesystem/matchers.ts
+++ b/src/smartcontracts/typesystem/matchers.ts
@@ -12,6 +12,7 @@ import { TokenIdentifierType, TokenIdentifierValue } from "./tokenIdentifier";
 import { Tuple, TupleType } from "./tuple";
 import { Type, PrimitiveType, PrimitiveValue } from "./types";
 import { ArrayVec, ArrayVecType } from "./genericArray";
+import { TypedValue } from "./types";
 
 // TODO: Extend functionality or rename wrt. restricted / reduced functionality (not all types are handled: composite, variadic).
 export function onTypeSelect<TResult>(
@@ -27,25 +28,25 @@ export function onTypeSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (type instanceof OptionType) {
+    if (type.hasConstructorInHierarchy(OptionType.name)) {
         return selectors.onOption();
     }
-    if (type instanceof ListType) {
+    if (type.hasConstructorInHierarchy(ListType.name)) {
         return selectors.onList();
     }
-    if (type instanceof ArrayVecType) {
+    if (type.hasConstructorInHierarchy(ArrayVecType.name)) {
         return selectors.onArray();
     }
-    if (type instanceof PrimitiveType) {
+    if (type.hasConstructorInHierarchy(PrimitiveType.name)) {
         return selectors.onPrimitive();
     }
-    if (type instanceof StructType) {
+    if (type.hasConstructorInHierarchy(StructType.name)) {
         return selectors.onStruct();
     }
-    if (type instanceof TupleType) {
+    if (type.hasConstructorInHierarchy(TupleType.name)) {
         return selectors.onTuple();
     }
-    if (type instanceof EnumType) {
+    if (type.hasConstructorInHierarchy(EnumType.name)) {
         return selectors.onEnum();
     }
 
@@ -57,7 +58,7 @@ export function onTypeSelect<TResult>(
 }
 
 export function onTypedValueSelect<TResult>(
-    value: any,
+    value: TypedValue,
     selectors: {
         onPrimitive: () => TResult;
         onOption: () => TResult;
@@ -152,25 +153,25 @@ export function onPrimitiveTypeSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (type instanceof BooleanType) {
+    if (type.hasConstructorInHierarchy(BooleanType.name)) {
         return selectors.onBoolean();
     }
-    if (type instanceof NumericalType) {
+    if (type.hasConstructorInHierarchy(NumericalType.name)) {
         return selectors.onNumerical();
     }
-    if (type instanceof AddressType) {
+    if (type.hasConstructorInHierarchy(AddressType.name)) {
         return selectors.onAddress();
     }
-    if (type instanceof BytesType) {
+    if (type.hasConstructorInHierarchy(BytesType.name)) {
         return selectors.onBytes();
     }
-    if (type instanceof H256Type) {
+    if (type.hasConstructorInHierarchy(H256Type.name)) {
         return selectors.onH256();
     }
-    if (type instanceof TokenIdentifierType) {
+    if (type.hasConstructorInHierarchy(TokenIdentifierType.name)) {
         return selectors.onTokenIndetifier();
     }
-    if (type instanceof NothingType) {
+    if (type.hasConstructorInHierarchy(NothingType.name)) {
         return selectors.onNothing();
     }
     if (selectors.onOther) {

--- a/src/smartcontracts/typesystem/matchers.ts
+++ b/src/smartcontracts/typesystem/matchers.ts
@@ -28,25 +28,25 @@ export function onTypeSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (type.hasConstructorInHierarchy(OptionType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(OptionType.name)) {
         return selectors.onOption();
     }
-    if (type.hasConstructorInHierarchy(ListType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(ListType.name)) {
         return selectors.onList();
     }
-    if (type.hasConstructorInHierarchy(ArrayVecType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(ArrayVecType.name)) {
         return selectors.onArray();
     }
-    if (type.hasConstructorInHierarchy(PrimitiveType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(PrimitiveType.name)) {
         return selectors.onPrimitive();
     }
-    if (type.hasConstructorInHierarchy(StructType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(StructType.name)) {
         return selectors.onStruct();
     }
-    if (type.hasConstructorInHierarchy(TupleType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(TupleType.name)) {
         return selectors.onTuple();
     }
-    if (type.hasConstructorInHierarchy(EnumType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(EnumType.name)) {
         return selectors.onEnum();
     }
 
@@ -70,25 +70,25 @@ export function onTypedValueSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (value.hasConstructorInHierarchy(PrimitiveValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(PrimitiveValue.name)) {
         return selectors.onPrimitive();
     }
-    if (value.hasConstructorInHierarchy(OptionValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(OptionValue.name)) {
         return selectors.onOption();
     }
-    if (value.hasConstructorInHierarchy(List.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(List.name)) {
         return selectors.onList();
     }
-    if (value.hasConstructorInHierarchy(ArrayVec.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(ArrayVec.name)) {
         return selectors.onArray();
     }
-    if (value.hasConstructorInHierarchy(Struct.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(Struct.name)) {
         return selectors.onStruct();
     }
-    if (value.hasConstructorInHierarchy(Tuple.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(Tuple.name)) {
         return selectors.onTuple();
     }
-    if (value.hasConstructorInHierarchy(EnumValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(EnumValue.name)) {
         return selectors.onEnum();
     }
 
@@ -112,25 +112,25 @@ export function onPrimitiveValueSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (value.hasConstructorInHierarchy(BooleanValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(BooleanValue.name)) {
         return selectors.onBoolean();
     }
-    if (value.hasConstructorInHierarchy(NumericalValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(NumericalValue.name)) {
         return selectors.onNumerical();
     }
-    if (value.hasConstructorInHierarchy(AddressValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(AddressValue.name)) {
         return selectors.onAddress();
     }
-    if (value.hasConstructorInHierarchy(BytesValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(BytesValue.name)) {
         return selectors.onBytes();
     }
-    if (value.hasConstructorInHierarchy(H256Value.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(H256Value.name)) {
         return selectors.onH256();
     }
-    if (value.hasConstructorInHierarchy(TokenIdentifierValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(TokenIdentifierValue.name)) {
         return selectors.onTypeIdentifier();
     }
-    if (value.hasConstructorInHierarchy(NothingValue.name)) {
+    if (value.hasJavascriptConstructorInHierarchy(NothingValue.name)) {
         return selectors.onNothing();
     }
     if (selectors.onOther) {
@@ -153,25 +153,25 @@ export function onPrimitiveTypeSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (type.hasConstructorInHierarchy(BooleanType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(BooleanType.name)) {
         return selectors.onBoolean();
     }
-    if (type.hasConstructorInHierarchy(NumericalType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(NumericalType.name)) {
         return selectors.onNumerical();
     }
-    if (type.hasConstructorInHierarchy(AddressType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(AddressType.name)) {
         return selectors.onAddress();
     }
-    if (type.hasConstructorInHierarchy(BytesType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(BytesType.name)) {
         return selectors.onBytes();
     }
-    if (type.hasConstructorInHierarchy(H256Type.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(H256Type.name)) {
         return selectors.onH256();
     }
-    if (type.hasConstructorInHierarchy(TokenIdentifierType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(TokenIdentifierType.name)) {
         return selectors.onTokenIndetifier();
     }
-    if (type.hasConstructorInHierarchy(NothingType.name)) {
+    if (type.hasJavascriptConstructorInHierarchy(NothingType.name)) {
         return selectors.onNothing();
     }
     if (selectors.onOther) {

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -100,20 +100,21 @@ export class TypeMapper {
     mapRecursiveType(type: Type): Type | null {
         let isGeneric = type.isGenericType();
 
-        if (type instanceof EnumType) {
+        if (type.hasJavascriptConstructor(EnumType.name)) {
             // This will call mapType() recursively, for all the enum variant fields.
-            return this.mapEnumType(type);
+            return this.mapEnumType(<EnumType>type);
         }
 
-        if (type instanceof StructType) {
+        if (type.hasJavascriptConstructor(StructType.name)) {
             // This will call mapType() recursively, for all the struct's fields.
-            return this.mapStructType(type);
+            return this.mapStructType(<StructType>type);
         }
 
         if (isGeneric) {
             // This will call mapType() recursively, for all the type parameters.
             return this.mapGenericType(type);
         }
+        
         return null;
     }
 

--- a/src/smartcontracts/typesystem/types.spec.ts
+++ b/src/smartcontracts/typesystem/types.spec.ts
@@ -44,4 +44,12 @@ describe("test types", () => {
         assert.isTrue(parser.parse("Option<u32>").equals(new OptionType(new U32Type())));
         assert.isTrue(parser.parse("utf-8 string").equals(new StringType()));
     });
+
+    it("should get fully qualified name", () => {
+        assert.equal(new Type("foo").getFullyQualifiedName(), "erdjs:types:foo");
+        assert.equal(new U32Type().getFullyQualifiedName(), "erdjs:types:u32");
+        assert.equal(parser.parse("MultiResultVec<u32>").getFullyQualifiedName(), "erdjs:types:MultiResultVec<erdjs:types:u32>");
+        assert.equal(parser.parse("utf-8 string").getFullyQualifiedName(), "erdjs:types:utf-8 string");
+        assert.equal(parser.parse("Option<u32>").getFullyQualifiedName(), "erdjs:types:Option<erdjs:types:u32>");
+    });
 });

--- a/src/smartcontracts/typesystem/types.spec.ts
+++ b/src/smartcontracts/typesystem/types.spec.ts
@@ -2,12 +2,13 @@ import * as errors from "../../errors";
 import { assert } from "chai";
 import { NumericalValue, StringType } from ".";
 import { I64Type, U16Type, U32Type, U32Value, U8Type } from "./numerical";
-import { PrimitiveType, Type } from "./types";
+import { PrimitiveType, Type, NullType } from "./types";
 import { BooleanType } from "./boolean";
 import { AddressType } from "./address";
 import { OptionType } from "./generic";
 import { TypeExpressionParser } from "./typeExpressionParser";
 import BigNumber from "bignumber.js";
+import { BytesType} from "./bytes";
 
 describe("test types", () => {
     let parser = new TypeExpressionParser();
@@ -31,6 +32,11 @@ describe("test types", () => {
         assert.isFalse((new AddressType()).isAssignableFrom(new BooleanType()));
         assert.isFalse((new U32Type()).isAssignableFrom(new BooleanType()));
         assert.isFalse((new U32Type()).isAssignableFrom(new PrimitiveType("PrimitiveType")));
+
+        assert.isTrue(new BytesType().isAssignableFrom(new BytesType()));
+        assert.isTrue(new U32Type().isAssignableFrom(parser.parse("u32")));
+        assert.isTrue(new Type("u32").isAssignableFrom(new U32Type()));
+        assert.isTrue(new OptionType(new U32Type()).isAssignableFrom(new OptionType(new NullType())));
     });
 
     it("should report equality", () => {

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -21,6 +21,17 @@ export class Type {
         return this.name;
     }
 
+    /**
+     * Gets the fully qualified name of the type, to allow for better (efficient and non-ambiguous) type comparison within erdjs' typesystem.
+     */
+    getFullyQualifiedName(): string {
+        let joinedTypeParameters = this.getTypeParameters().map(type => type.getFullyQualifiedName()).join(", ");
+
+        return this.isGenericType() ? 
+            `erdjs:types:${this.getName()}<${joinedTypeParameters}>` : 
+            `erdjs:types:${this.getName()}`;
+    }
+
     getTypeParameters(): Type[] {
         return this.typeParameters;
     }
@@ -33,7 +44,6 @@ export class Type {
         guardTrue(this.typeParameters.length > 0, "type parameters length > 0");
         return this.typeParameters[0];
     }
-
 
     /**
      * Generates type expressions similar to elrond-wasm-rs. 
@@ -49,13 +59,7 @@ export class Type {
     }
 
     static equals(a: Type, b: Type): boolean {
-        // Workaround that seems to always work properly. Most probable reasons: 
-        // - ES6 is quite strict about enumerating over the properties on an object.
-        // - toJSON() returns an object literal (most probably, this results in deterministic iteration in all browser implementations).
-        let aJson = JSON.stringify(a.toJSON());
-        let bJson = JSON.stringify(b.toJSON());
-
-        return aJson == bJson;
+        return a.getFullyQualifiedName() == b.getFullyQualifiedName();
     }
 
     static equalsMany(a: Type[], b: Type[]) {

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -38,8 +38,7 @@ export class Type {
     }
 
     hasJavascriptConstructorInHierarchy(javascriptConstructorName: string): boolean {
-        let constructorsNames = getJavascriptConstructorsNamesInHierarchy(this, prototype => prototype.belongsToTypesystem);
-        return constructorsNames.includes(javascriptConstructorName);
+        return getJavascriptConstructorsNamesInHierarchy(this, prototype => prototype.belongsToTypesystem).includes(javascriptConstructorName);
     }
 
     getTypeParameters(): Type[] {
@@ -232,8 +231,7 @@ export abstract class TypedValue {
     }
 
     hasJavascriptConstructorInHierarchy(javascriptConstructorName: string): boolean {
-        let constructorsNames = getJavascriptConstructorsNamesInHierarchy(this, prototype => prototype.belongsToTypesystem);
-        return constructorsNames.includes(javascriptConstructorName);
+        return getJavascriptConstructorsNamesInHierarchy(this, prototype => prototype.belongsToTypesystem).includes(javascriptConstructorName);
     }
 
     /**

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -247,7 +247,7 @@ export abstract class PrimitiveValue extends TypedValue {
 }
 
 export function isTyped(value: any) {
-    return value.belongsToTypesystem;
+    return value.belongsToTypesystem !== undefined;
 }
 
 export class TypePlaceholder extends Type {

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -1,4 +1,4 @@
-import { getJavascriptConstructorsNamesInHierarchy, getJavascriptPrototypesInHierarchy } from "../../reflection";
+import { getJavascriptConstructorsNamesInHierarchy, getJavascriptPrototypesInHierarchy, hasJavascriptConstructor } from "../../reflection";
 import { guardTrue, guardValueIsSet } from "../../utils";
 
 /**
@@ -34,7 +34,7 @@ export class Type {
     }
 
     hasJavascriptConstructor(javascriptConstructorName: string): boolean {
-        return this.constructor.name == javascriptConstructorName;
+        return hasJavascriptConstructor(this, javascriptConstructorName);
     }
 
     hasJavascriptConstructorInHierarchy(javascriptConstructorName: string): boolean {
@@ -228,7 +228,7 @@ export abstract class TypedValue {
     abstract valueOf(): any;
 
     hasJavascriptConstructor(javascriptConstructorName: string): boolean {
-        return this.constructor.name == javascriptConstructorName;
+        return hasJavascriptConstructor(this, javascriptConstructorName);
     }
 
     hasJavascriptConstructorInHierarchy(javascriptConstructorName: string): boolean {

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -33,7 +33,11 @@ export class Type {
             `erdjs:types:${this.getName()}`;
     }
 
-    hasConstructorInHierarchy(javascriptConstructorName: string): boolean {
+    hasJavascriptConstructor(javascriptConstructorName: string): boolean {
+        return this.constructor.name == javascriptConstructorName;
+    }
+
+    hasJavascriptConstructorInHierarchy(javascriptConstructorName: string): boolean {
         let constructorsNames = getJavascriptConstructorsNamesInHierarchy(this, prototype => prototype.belongsToTypesystem);
         return constructorsNames.includes(javascriptConstructorName);
     }
@@ -105,15 +109,15 @@ export class Type {
         let fullyQualifiedNameOfThis = this.getFullyQualifiedName();
         let fullyQualifiedNamesInHierarchyOfOther = Type.getFullyQualifiedNamesInHierarchy(other);
         if (fullyQualifiedNamesInHierarchyOfOther.includes(fullyQualifiedNameOfThis)) {
-                return true;
-            }
+            return true;
+        }
 
         let javascriptConstructorNameOfThis = this.constructor.name;
         let javascriptConstructorNamesInHierarchyOfOther = getJavascriptConstructorsNamesInHierarchy(other, prototype => prototype.belongsToTypesystem);
         if (javascriptConstructorNamesInHierarchyOfOther.includes(javascriptConstructorNameOfThis)) {
             return true;
         }
-        
+
         return false;
     }
 
@@ -223,7 +227,7 @@ export abstract class TypedValue {
     abstract equals(other: any): boolean;
     abstract valueOf(): any;
 
-    hasConstructorInHierarchy(javascriptConstructorName: string): boolean {
+    hasJavascriptConstructorInHierarchy(javascriptConstructorName: string): boolean {
         let constructorsNames = getJavascriptConstructorsNamesInHierarchy(this, prototype => prototype.belongsToTypesystem);
         return constructorsNames.includes(javascriptConstructorName);
     }
@@ -241,7 +245,7 @@ export abstract class PrimitiveValue extends TypedValue {
 }
 
 export function isTyped(value: any) {
-    return value instanceof TypedValue;
+    return value.belongsToTypesystem;
 }
 
 export class TypePlaceholder extends Type {

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -227,6 +227,10 @@ export abstract class TypedValue {
     abstract equals(other: any): boolean;
     abstract valueOf(): any;
 
+    hasJavascriptConstructor(javascriptConstructorName: string): boolean {
+        return this.constructor.name == javascriptConstructorName;
+    }
+
     hasJavascriptConstructorInHierarchy(javascriptConstructorName: string): boolean {
         let constructorsNames = getJavascriptConstructorsNamesInHierarchy(this, prototype => prototype.belongsToTypesystem);
         return constructorsNames.includes(javascriptConstructorName);

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -90,9 +90,26 @@ export class Type {
      *  - https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)
      *  - https://docs.microsoft.com/en-us/dotnet/standard/generics/covariance-and-contravariance
      */
-    isAssignableFrom(type: Type): boolean {
-        let invariantTypeParameters = Type.equalsMany(this.getTypeParameters(), type.getTypeParameters());
-        return type instanceof this.constructor && invariantTypeParameters;
+    isAssignableFrom(other: Type): boolean {
+        let invariantTypeParameters = Type.equalsMany(this.getTypeParameters(), other.getTypeParameters());
+        if (!invariantTypeParameters) {
+            return false;
+        }
+
+        let otherPrototype: any = Object.getPrototypeOf(other);
+        
+        while (otherPrototype && otherPrototype.getFullyQualifiedName) {
+            let thisName = this.getFullyQualifiedName();
+            let otherName = otherPrototype.getFullyQualifiedName.call(other);
+
+            if (thisName == otherName) {
+                return true;
+            }
+
+            otherPrototype = Object.getPrototypeOf(otherPrototype);
+        }
+        
+        return false;
     }
 
     /**

--- a/src/smartcontracts/wrapper/contractWrapper.local.net.spec.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.local.net.spec.ts
@@ -53,7 +53,7 @@ describe("test smart contract interactor", function () {
         await lottery.call.start("lucky", Balance.egld(1), null, null, 1, null, null);
 
         let status = await lottery.query.status("lucky");
-        assert.equal(status.valueOf(), "Running");
+        assert.equal(status.valueOf().name, "Running");
 
         let info = await lottery.query.lotteryInfo("lucky");
         // Ignore "deadline" field in our test


### PR DESCRIPTION
Related to:
 - https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/128
 - https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/143

Usages of `instanceof` lead to fragile type matching and type checking in erdjs' typesystem. In this PR we replace most occurrences of JavaScript's `instanceof` operator with a custom approach, tailored to erdjs's typesystem.

This isn't a breaking change.