### PR TITLE
Fix data fetching from the blockchain - wait before polling for the first time

### DIFF
--- a/src/transactionWatcher.ts
+++ b/src/transactionWatcher.ts
@@ -102,6 +102,8 @@ export class TransactionWatcher {
         });
 
         while (!stop) {
+            await periodicTimer.start(this.pollingInterval);
+
             try {
                 fetchedData = await doFetch();
                 Logger.debug("TransactionWatcher.awaitConditionally(): fetched data.", this.hash.toString())
@@ -120,8 +122,6 @@ export class TransactionWatcher {
                     throw error;
                 }
             }
-
-            await periodicTimer.start(this.pollingInterval);
         }
 
         if (!timeoutTimer.isStopped()) {


### PR DESCRIPTION
**Current behaviour:**

The polling happens right away, so the user gets the `TransactionWatcher.awaitConditionally(): cannot (yet) fetch data.` error in almost all the cases.

**Desired behaviour:**
Instead, we should do the first polling after X milliseconds so we can guarantee a higher success rate when fetching the data from the blockchain.

See https://github.com/ElrondNetwork/elrond-sdk-erdjs/issues/151 for the full context.