### PR TITLE
remove console logging from contractWrapper

### DIFF
--- a/src/smartcontracts/wrapper/contractWrapper.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.ts
@@ -138,7 +138,6 @@ export class ContractWrapper extends ChainSendContext {
             query.caller = optionalSender.address;
         }
         let response = await provider.queryContract(query);
-        console.log("got response...", response);
         let queryResponseBundle = interaction.interpretQueryResponse(response);
         let result = queryResponseBundle.queryResponse.unpackOutput();
         logger?.queryComplete(result, response);


### PR DESCRIPTION
Hello,

While creating interaction script for a smart contract, I found confusing looking through output because of this extra _**console.log**_ that is impossible to be suppressed.

ContractLogger should be the preferred way to log interactions.

Thank you!