### PR TITLE
erdjs v9.x: Hardcode class names for classes within erdjs' typesystem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Unreleased
  - TBD
 
+## [9.2.4]
+ - [Hardcode class names for classes within erdjs' typesystem.](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/164)
+
 ## [9.2.3]
  - [Fix log level in transaction watcher.](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/160)
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .PHONY: clean browser-tests
 
-browser-tests: out-browser-tests/erdjs-tests-unit.js out-browser-tests/erdjs-tests-localnet.js out-browser-tests/erdjs-tests-devnet.js out-browser-tests/erdjs-tests-testnet.js out-browser-tests/erdjs-tests-mainnet.js
+browser-tests: out-browser-tests/erdjs-tests-unit.js out-browser-tests/erdjs-tests-unit-min.js out-browser-tests/erdjs-tests-localnet.js out-browser-tests/erdjs-tests-devnet.js out-browser-tests/erdjs-tests-testnet.js out-browser-tests/erdjs-tests-mainnet.js
 
 out-browser-tests/erdjs-tests-unit.js: out-tests
 	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.net.spec.*') --require buffer/:buffer -o out-browser-tests/erdjs-tests-unit.js --standalone erdjs-tests -p esmify
+
+out-browser-tests/erdjs-tests-unit-min.js: out-tests
+	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.net.spec.*') --require buffer/:buffer -o out-browser-tests/erdjs-tests-unit-min.js --standalone erdjs-tests -p esmify -p tinyify
 
 out-browser-tests/erdjs-tests-localnet.js: out-tests
 	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.spec.*') $(shell find out-tests -type f -name '*.local.net.spec.js') --require buffer/:buffer -o out-browser-tests/erdjs-tests-localnet.js --standalone erdjs-tests -p esmify

--- a/browser-tests/index.html
+++ b/browser-tests/index.html
@@ -19,6 +19,11 @@
                         </button>
                     </li>
                     <li class="list-group-item">
+                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/erdjs-tests-unit-min.js')">
+                            Unit tests (minified code)
+                        </button>
+                    </li>
+                    <li class="list-group-item">
                         <button class="btn btn-link" onclick="runTests('/out-browser-tests/erdjs-tests-localnet.js')">
                             Integration tests - local testnet
                         </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@elrondnetwork/erdjs",
-    "version": "9.2.3",
+    "version": "9.2.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/erdjs",
-  "version": "9.2.3",
+  "version": "9.2.4",
   "description": "Smart Contracts interaction framework",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/reflection.ts
+++ b/src/reflection.ts
@@ -1,13 +1,3 @@
-export function hasJavascriptConstructor(obj: Object, javascriptConstructorName: string): boolean {
-    return obj.constructor.name == javascriptConstructorName;
-}
-
-export function getJavascriptConstructorsNamesInHierarchy(obj: Object, filter: (prototype: any) => boolean): string[] {
-    let prototypes = getJavascriptPrototypesInHierarchy(obj, filter);
-    let constructorNames = prototypes.map(prototype => prototype.constructor.name);
-    return constructorNames;
-}
-
 export function getJavascriptPrototypesInHierarchy(obj: Object, filter: (prototype: any) => boolean): Object[] {
     let prototypes: Object[] = [];
     let prototype: any = Object.getPrototypeOf(obj);

--- a/src/smartcontracts/argSerializer.ts
+++ b/src/smartcontracts/argSerializer.ts
@@ -52,10 +52,10 @@ export class ArgSerializer {
         function readValue(type: Type): TypedValue {
             // TODO: Use matchers.
 
-            if (type.hasJavascriptConstructor(OptionalType.name)) {
+            if (type.hasExactClass(OptionalType.ClassName)) {
                 let typedValue = readValue(type.getFirstTypeParameter());
                 return new OptionalValue(type, typedValue);
-            } else if (type.hasJavascriptConstructor(VariadicType.name)) {
+            } else if (type.hasExactClass(VariadicType.ClassName)) {
                 let typedValues = [];
 
                 while (!hasReachedTheEnd()) {
@@ -63,7 +63,7 @@ export class ArgSerializer {
                 }
 
                 return new VariadicValue(type, typedValues);
-            } else if (type.hasJavascriptConstructor(CompositeType.name)) {
+            } else if (type.hasExactClass(CompositeType.ClassName)) {
                 let typedValues = [];
 
                 for (const typeParameter of type.getTypeParameters()) {
@@ -132,17 +132,17 @@ export class ArgSerializer {
         function handleValue(value: TypedValue): void {
             // TODO: Use matchers.
 
-            if (value.hasJavascriptConstructor(OptionalValue.name)) {
+            if (value.hasExactClass(OptionalValue.ClassName)) {
                 let valueAsOptional = <OptionalValue>value;
                 if (valueAsOptional.isSet()) {
                     handleValue(valueAsOptional.getTypedValue());
                 }
-            } else if (value.hasJavascriptConstructor(VariadicValue.name)) {
+            } else if (value.hasExactClass(VariadicValue.ClassName)) {
                 let valueAsVariadic = <VariadicValue>value;
                 for (const item of valueAsVariadic.getItems()) {
                     handleValue(item);
                 }
-            } else if (value.hasJavascriptConstructor(CompositeValue.name)) {
+            } else if (value.hasExactClass(CompositeValue.ClassName)) {
                 let valueAsComposite = <CompositeValue>value;
                 for (const item of valueAsComposite.getItems()) {
                     handleValue(item);

--- a/src/smartcontracts/typesystem/abiRegistry.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.ts
@@ -76,7 +76,7 @@ export class AbiRegistry {
         return names.map((name) => this.getInterface(name));
     }
     getStruct(name: string): StructType {
-        let result = this.customTypes.find((e) => e.getName() == name && e.hasJavascriptConstructor(StructType.name));
+        let result = this.customTypes.find((e) => e.getName() == name && e.hasExactClass(StructType.ClassName));
         guardValueIsSetWithMessage(`struct [${name}] not found`, result);
         return <StructType>result!;
     }
@@ -84,7 +84,7 @@ export class AbiRegistry {
         return names.map((name) => this.getStruct(name));
     }
     getEnum(name: string): EnumType {
-        let result = this.customTypes.find((e) => e.getName() == name && e.hasJavascriptConstructor(EnumType.name));
+        let result = this.customTypes.find((e) => e.getName() == name && e.hasExactClass(EnumType.ClassName));
         guardValueIsSetWithMessage(`enum [${name}] not found`, result);
         return <EnumType>result!;
     }

--- a/src/smartcontracts/typesystem/address.ts
+++ b/src/smartcontracts/typesystem/address.ts
@@ -2,8 +2,14 @@ import { Address } from "../../address";
 import { PrimitiveType, PrimitiveValue } from "./types";
 
 export class AddressType extends PrimitiveType {
+    static ClassName = "AddressType";
+
     constructor() {
         super("Address");
+    }
+
+    getClassName(): string {
+        return AddressType.ClassName;
     }
 }
 
@@ -11,11 +17,16 @@ export class AddressType extends PrimitiveType {
  * An address fed to or fetched from a Smart Contract contract, as an immutable abstraction.
  */
 export class AddressValue extends PrimitiveValue {
+    static ClassName = "AddressValue";
     private readonly value: Address;
 
     constructor(value: Address) {
         super(new AddressType());
         this.value = value;
+    }
+
+    getClassName(): string {
+        return AddressValue.ClassName;
     }
 
     /**

--- a/src/smartcontracts/typesystem/algebraic.ts
+++ b/src/smartcontracts/typesystem/algebraic.ts
@@ -5,12 +5,19 @@ import { Type, TypeCardinality, TypedValue } from "./types";
  * An optional is an algebraic type. It holds zero or one values.
  */
 export class OptionalType extends Type {
+    static ClassName = "OptionalType";
+
     constructor(typeParameter: Type) {
         super("Optional", [typeParameter], TypeCardinality.variable(1));
+    }
+
+    getClassName(): string {
+        return OptionalType.ClassName;
     }
 }
 
 export class OptionalValue extends TypedValue {
+    static ClassName = "OptionalValue";
     private readonly value: TypedValue | null;
 
     constructor(type: OptionalType, value: TypedValue | null = null) {
@@ -19,6 +26,10 @@ export class OptionalValue extends TypedValue {
         // TODO: assert value is of type type.getFirstTypeParameter()
 
         this.value = value;
+    }
+
+    getClassName(): string {
+        return OptionalValue.ClassName;
     }
 
     isSet(): boolean {

--- a/src/smartcontracts/typesystem/boolean.ts
+++ b/src/smartcontracts/typesystem/boolean.ts
@@ -1,8 +1,14 @@
 import { PrimitiveType, PrimitiveValue } from "./types";
 
 export class BooleanType extends PrimitiveType {
+    static ClassName = "BooleanType";
+
     constructor() {
         super("bool");
+    }
+
+    getClassName(): string {
+        return BooleanType.ClassName;
     }
 }
 
@@ -10,11 +16,16 @@ export class BooleanType extends PrimitiveType {
  * A boolean value fed to or fetched from a Smart Contract contract, as an immutable abstraction.
  */
 export class BooleanValue extends PrimitiveValue {
+    static ClassName = "BooleanValue";
     private readonly value: boolean;
 
     constructor(value: boolean) {
         super(new BooleanType());
         this.value = value;
+    }
+
+    getClassName(): string {
+        return BooleanValue.ClassName;
     }
 
     /**

--- a/src/smartcontracts/typesystem/bytes.ts
+++ b/src/smartcontracts/typesystem/bytes.ts
@@ -1,18 +1,28 @@
-import * as errors from "../../errors";
 import { PrimitiveType, PrimitiveValue } from "./types";
 
 export class BytesType extends PrimitiveType {
+    static ClassName = "BytesType";
+
     constructor() {
         super("bytes");
+    }
+
+    getClassName(): string {
+        return BytesType.ClassName;
     }
 }
 
 export class BytesValue extends PrimitiveValue {
+    static ClassName = "BytesValue";
     private readonly value: Buffer;
 
     constructor(value: Buffer) {
         super(new BytesType());
         this.value = value;
+    }
+
+    getClassName(): string {
+        return BytesValue.ClassName;
     }
 
     /**

--- a/src/smartcontracts/typesystem/composite.ts
+++ b/src/smartcontracts/typesystem/composite.ts
@@ -2,12 +2,19 @@ import { guardLength } from "../../utils";
 import { Type, TypeCardinality, TypedValue } from "./types";
 
 export class CompositeType extends Type {
+    static ClassName = "CompositeType";
+
     constructor(...typeParameters: Type[]) {
         super("Composite", typeParameters, TypeCardinality.variable(typeParameters.length));
+    }
+
+    getClassName(): string {
+        return CompositeType.ClassName;
     }
 }
 
 export class CompositeValue extends TypedValue {
+    static ClassName = "CompositeValue";
     private readonly items: TypedValue[];
 
     constructor(type: CompositeType, items: TypedValue[]) {
@@ -18,6 +25,10 @@ export class CompositeValue extends TypedValue {
         // TODO: assert type of each item (wrt. type.getTypeParameters()).
 
         this.items = items;
+    }
+
+    getClassName(): string {
+        return CompositeValue.ClassName;
     }
 
     static fromItems(...items: TypedValue[]): CompositeValue {

--- a/src/smartcontracts/typesystem/enum.ts
+++ b/src/smartcontracts/typesystem/enum.ts
@@ -5,11 +5,16 @@ import { CustomType, TypedValue } from "./types";
 const SimpleEnumMaxDiscriminant = 256;
 
 export class EnumType extends CustomType {
+    static ClassName = "EnumType";
     readonly variants: EnumVariantDefinition[] = [];
 
     constructor(name: string, variants: EnumVariantDefinition[]) {
         super(name);
         this.variants = variants;
+    }
+
+    getClassName(): string {
+        return EnumType.ClassName;
     }
 
     static fromJSON(json: { name: string; variants: any[] }): EnumType {
@@ -57,6 +62,7 @@ export class EnumVariantDefinition {
 }
 
 export class EnumValue extends TypedValue {
+    static ClassName = "EnumValue";
     readonly name: string;
     readonly discriminant: number;
     private readonly fields: Field[] = [];
@@ -69,6 +75,10 @@ export class EnumValue extends TypedValue {
 
         let definitions = variant.getFieldsDefinitions();
         Fields.checkTyping(this.fields, definitions);
+    }
+
+    getClassName(): string {
+        return EnumValue.ClassName;
     }
 
     /**

--- a/src/smartcontracts/typesystem/generic.ts
+++ b/src/smartcontracts/typesystem/generic.ts
@@ -4,30 +4,43 @@ import { Type, TypedValue, NullType, TypePlaceholder } from "./types";
 
 // TODO: Move to a new file, "genericOption.ts"
 export class OptionType extends Type {
+    static ClassName = "OptionType";
+
     constructor(typeParameter: Type) {
         super("Option", [typeParameter]);
     }
 
+    getClassName(): string {
+        return OptionType.ClassName;
+    }
+
     isAssignableFrom(type: Type): boolean {
-        if (!(type.hasJavascriptConstructor(OptionType.name))) {
+        if (!(type.hasExactClass(OptionType.ClassName))) {
             return false;
         }
 
         let invariantTypeParameters = this.getFirstTypeParameter().equals(type.getFirstTypeParameter());
-        let fakeCovarianceToNull = type.getFirstTypeParameter().hasJavascriptConstructor(NullType.name);
+        let fakeCovarianceToNull = type.getFirstTypeParameter().hasExactClass(NullType.ClassName);
         return invariantTypeParameters || fakeCovarianceToNull;
     }
 }
 
 // TODO: Move to a new file, "genericList.ts"
 export class ListType extends Type {
+    static ClassName = "ListType";
+
     constructor(typeParameter: Type) {
         super("List", [typeParameter]);
+    }
+
+    getClassName(): string {
+        return ListType.ClassName;
     }
 }
 
 // TODO: Move to a new file, "genericOption.ts"
 export class OptionValue extends TypedValue {
+    static ClassName = "OptionValue";
     private readonly value: TypedValue | null;
 
     constructor(type: OptionType, value: TypedValue | null = null) {
@@ -36,6 +49,10 @@ export class OptionValue extends TypedValue {
         // TODO: assert value is of type type.getFirstTypeParameter()
 
         this.value = value;
+    }
+
+    getClassName(): string {
+        return OptionValue.ClassName;
     }
 
     /**
@@ -80,6 +97,7 @@ export class OptionValue extends TypedValue {
 // TODO: Rename to ListValue, for consistency (though the term is slighly unfortunate).
 // Question for review: or not?
 export class List extends TypedValue {
+    static ClassName = "List";
     private readonly backingCollection: CollectionOfTypedValues;
 
     /**
@@ -93,6 +111,10 @@ export class List extends TypedValue {
         // TODO: assert items are of type type.getFirstTypeParameter()
 
         this.backingCollection = new CollectionOfTypedValues(items);
+    }
+
+    getClassName(): string {
+        return List.ClassName;
     }
 
     static fromItems(items: TypedValue[]): List {

--- a/src/smartcontracts/typesystem/genericArray.ts
+++ b/src/smartcontracts/typesystem/genericArray.ts
@@ -4,6 +4,7 @@ import { Type, TypedValue } from "./types";
 
 // A type for known-length arrays. E.g. "array20", "array32", "array64" etc.
 export class ArrayVecType extends Type {
+    static ClassName = "ArrayVecType";
     readonly length: number;
 
     constructor(length: number, typeParameter: Type) {
@@ -12,15 +13,24 @@ export class ArrayVecType extends Type {
         guardTrue(length > 0, "array length > 0");
         this.length = length;
     }
+
+    getClassName(): string {
+        return ArrayVecType.ClassName;
+    }
 }
 
 export class ArrayVec extends TypedValue {
+    static ClassName = "ArrayVec";
     private readonly backingCollection: CollectionOfTypedValues;
 
     constructor(type: ArrayVecType, items: TypedValue[]) {
         super(type);
         guardLength(items, type.length);
         this.backingCollection = new CollectionOfTypedValues(items);
+    }
+
+    getClassName(): string {
+        return ArrayVec.ClassName;
     }
 
     getLength(): number {

--- a/src/smartcontracts/typesystem/h256.ts
+++ b/src/smartcontracts/typesystem/h256.ts
@@ -1,18 +1,28 @@
-import * as errors from "../../errors";
 import { PrimitiveType, PrimitiveValue } from "./types";
 
 export class H256Type extends PrimitiveType {
+    static ClassName = "H256Type";
+
     constructor() {
         super("H256");
+    }
+
+    getClassName(): string {
+        return H256Type.ClassName;
     }
 }
 
 export class H256Value extends PrimitiveValue {
+    static ClassName = "H256Value";
     private readonly value: Buffer;
 
     constructor(value: Buffer) {
         super(new H256Type());
         this.value = value;
+    }
+
+    getClassName(): string {
+        return H256Value.ClassName;
     }
 
     /**

--- a/src/smartcontracts/typesystem/matchers.ts
+++ b/src/smartcontracts/typesystem/matchers.ts
@@ -29,25 +29,25 @@ export function onTypeSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (type.hasJavascriptConstructorInHierarchy(OptionType.name)) {
+    if (type.hasExactClass(OptionType.ClassName)) {
         return selectors.onOption();
     }
-    if (type.hasJavascriptConstructorInHierarchy(ListType.name)) {
+    if (type.hasExactClass(ListType.ClassName)) {
         return selectors.onList();
     }
-    if (type.hasJavascriptConstructorInHierarchy(ArrayVecType.name)) {
+    if (type.hasExactClass(ArrayVecType.ClassName)) {
         return selectors.onArray();
     }
-    if (type.hasJavascriptConstructorInHierarchy(PrimitiveType.name)) {
+    if (type.hasClassOrSuperclass(PrimitiveType.ClassName)) {
         return selectors.onPrimitive();
     }
-    if (type.hasJavascriptConstructorInHierarchy(StructType.name)) {
+    if (type.hasExactClass(StructType.ClassName)) {
         return selectors.onStruct();
     }
-    if (type.hasJavascriptConstructorInHierarchy(TupleType.name)) {
+    if (type.hasExactClass(TupleType.ClassName)) {
         return selectors.onTuple();
     }
-    if (type.hasJavascriptConstructorInHierarchy(EnumType.name)) {
+    if (type.hasExactClass(EnumType.ClassName)) {
         return selectors.onEnum();
     }
 
@@ -71,25 +71,25 @@ export function onTypedValueSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (value.hasJavascriptConstructorInHierarchy(PrimitiveValue.name)) {
+    if (value.hasClassOrSuperclass(PrimitiveValue.ClassName)) {
         return selectors.onPrimitive();
     }
-    if (value.hasJavascriptConstructorInHierarchy(OptionValue.name)) {
+    if (value.hasExactClass(OptionValue.ClassName)) {
         return selectors.onOption();
     }
-    if (value.hasJavascriptConstructorInHierarchy(List.name)) {
+    if (value.hasExactClass(List.ClassName)) {
         return selectors.onList();
     }
-    if (value.hasJavascriptConstructorInHierarchy(ArrayVec.name)) {
+    if (value.hasExactClass(ArrayVec.ClassName)) {
         return selectors.onArray();
     }
-    if (value.hasJavascriptConstructorInHierarchy(Struct.name)) {
+    if (value.hasExactClass(Struct.ClassName)) {
         return selectors.onStruct();
     }
-    if (value.hasJavascriptConstructorInHierarchy(Tuple.name)) {
+    if (value.hasExactClass(Tuple.ClassName)) {
         return selectors.onTuple();
     }
-    if (value.hasJavascriptConstructorInHierarchy(EnumValue.name)) {
+    if (value.hasExactClass(EnumValue.ClassName)) {
         return selectors.onEnum();
     }
 
@@ -114,28 +114,28 @@ export function onPrimitiveValueSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (value.hasJavascriptConstructorInHierarchy(BooleanValue.name)) {
+    if (value.hasExactClass(BooleanValue.ClassName)) {
         return selectors.onBoolean();
     }
-    if (value.hasJavascriptConstructorInHierarchy(NumericalValue.name)) {
+    if (value.hasClassOrSuperclass(NumericalValue.ClassName)) {
         return selectors.onNumerical();
     }
-    if (value.hasJavascriptConstructorInHierarchy(AddressValue.name)) {
+    if (value.hasExactClass(AddressValue.ClassName)) {
         return selectors.onAddress();
     }
-    if (value.hasJavascriptConstructorInHierarchy(BytesValue.name)) {
+    if (value.hasExactClass(BytesValue.ClassName)) {
         return selectors.onBytes();
     }
-    if (value.hasJavascriptConstructorInHierarchy(StringValue.name)) {
+    if (value.hasExactClass(StringValue.ClassName)) {
         return selectors.onString();
     }
-    if (value.hasJavascriptConstructorInHierarchy(H256Value.name)) {
+    if (value.hasExactClass(H256Value.ClassName)) {
         return selectors.onH256();
     }
-    if (value.hasJavascriptConstructorInHierarchy(TokenIdentifierValue.name)) {
+    if (value.hasExactClass(TokenIdentifierValue.ClassName)) {
         return selectors.onTypeIdentifier();
     }
-    if (value.hasJavascriptConstructorInHierarchy(NothingValue.name)) {
+    if (value.hasExactClass(NothingValue.ClassName)) {
         return selectors.onNothing();
     }
     if (selectors.onOther) {
@@ -159,28 +159,28 @@ export function onPrimitiveTypeSelect<TResult>(
         onOther?: () => TResult;
     }
 ): TResult {
-    if (type.hasJavascriptConstructorInHierarchy(BooleanType.name)) {
+    if (type.hasExactClass(BooleanType.ClassName)) {
         return selectors.onBoolean();
     }
-    if (type.hasJavascriptConstructorInHierarchy(NumericalType.name)) {
+    if (type.hasClassOrSuperclass(NumericalType.ClassName)) {
         return selectors.onNumerical();
     }
-    if (type.hasJavascriptConstructorInHierarchy(AddressType.name)) {
+    if (type.hasExactClass(AddressType.ClassName)) {
         return selectors.onAddress();
     }
-    if (type.hasJavascriptConstructorInHierarchy(BytesType.name)) {
+    if (type.hasExactClass(BytesType.ClassName)) {
         return selectors.onBytes();
     }
-    if (type.hasJavascriptConstructorInHierarchy(StringType.name)) {
+    if (type.hasExactClass(StringType.ClassName)) {
         return selectors.onString();
     }
-    if (type.hasJavascriptConstructorInHierarchy(H256Type.name)) {
+    if (type.hasExactClass(H256Type.ClassName)) {
         return selectors.onH256();
     }
-    if (type.hasJavascriptConstructorInHierarchy(TokenIdentifierType.name)) {
+    if (type.hasExactClass(TokenIdentifierType.ClassName)) {
         return selectors.onTokenIndetifier();
     }
-    if (type.hasJavascriptConstructorInHierarchy(NothingType.name)) {
+    if (type.hasExactClass(NothingType.ClassName)) {
         return selectors.onNothing();
     }
     if (selectors.onOther) {

--- a/src/smartcontracts/typesystem/nothing.ts
+++ b/src/smartcontracts/typesystem/nothing.ts
@@ -1,14 +1,26 @@
 import { PrimitiveType, PrimitiveValue } from "./types";
 
 export class NothingType extends PrimitiveType {
+    static ClassName = "NothingType";
+
     constructor() {
         super("nothing");
+    }
+
+    getClassName(): string {
+        return NothingType.ClassName;
     }
 }
 
 export class NothingValue extends PrimitiveValue {
+    static ClassName = "NothingValue";
+
     constructor() {
         super(new NothingType());
+    }
+
+    getClassName(): string {
+        return NothingValue.ClassName;
     }
 
     equals(_other: NothingValue): boolean {

--- a/src/smartcontracts/typesystem/numerical.ts
+++ b/src/smartcontracts/typesystem/numerical.ts
@@ -3,6 +3,8 @@ import { PrimitiveType, PrimitiveValue, Type } from "./types";
 import BigNumber from "bignumber.js";
 
 export class NumericalType extends PrimitiveType {
+    static ClassName = "NumericalType";
+
     readonly sizeInBytes: number;
     readonly withSign: boolean;
 
@@ -10,6 +12,10 @@ export class NumericalType extends PrimitiveType {
         super(name);
         this.sizeInBytes = sizeInBytes;
         this.withSign = withSign;
+    }
+
+    getClassName(): string {
+        return NumericalType.ClassName;
     }
 
     hasFixedSize(): boolean {
@@ -22,62 +28,122 @@ export class NumericalType extends PrimitiveType {
 }
 
 export class U8Type extends NumericalType {
+    static ClassName = "U8Type";
+
     constructor() {
         super("u8", 1, false);
+    }
+
+    getClassName(): string {
+        return U8Type.ClassName;
     }
 }
 
 export class I8Type extends NumericalType {
+    static ClassName = "I8Type";
+
     constructor() {
         super("i8", 1, true);
+    }
+
+    getClassName(): string {
+        return I8Type.ClassName;
     }
 }
 
 export class U16Type extends NumericalType {
+    static ClassName = "U16Type";
+
     constructor() {
         super("u16", 2, false);
+    }
+
+    getClassName(): string {
+        return U16Type.ClassName;
     }
 }
 
 export class I16Type extends NumericalType {
+    static ClassName = "I16Type";
+
     constructor() {
         super("i16", 2, true);
+    }
+
+    getClassName(): string {
+        return I16Type.ClassName;
     }
 }
 
 export class U32Type extends NumericalType {
+    static ClassName = "U32Type";
+
     constructor() {
         super("u32", 4, false);
+    }
+
+    getClassName(): string {
+        return U32Type.ClassName;
     }
 }
 
 export class I32Type extends NumericalType {
+    static ClassName = "I32Type";
+
     constructor() {
         super("i32", 4, true);
+    }
+
+    getClassName(): string {
+        return I32Type.ClassName;
     }
 }
 
 export class U64Type extends NumericalType {
+    static ClassName = "U64Type";
+
     constructor() {
         super("u64", 8, false);
+    }
+
+    getClassName(): string {
+        return U64Type.ClassName;
     }
 }
 
 export class I64Type extends NumericalType {
+    static ClassName = "I64Type";
+
     constructor() {
         super("i64", 8, true);
+    }
+
+    getClassName(): string {
+        return I64Type.ClassName;
     }
 }
 
 export class BigUIntType extends NumericalType {
+    static ClassName = "BigUIntType";
+
     constructor() {
         super("BigUint", 0, false);
+    }
+
+    getClassName(): string {
+        return BigUIntType.ClassName;
     }
 }
 
 export class BigIntType extends NumericalType {
+    static ClassName = "BigIntType";
+
     constructor() {
         super("Bigint", 0, true);
+    }
+
+    getClassName(): string {
+        return BigIntType.ClassName;
     }
 }
 
@@ -85,6 +151,7 @@ export class BigIntType extends NumericalType {
  * A numerical value fed to or fetched from a Smart Contract contract, as a strongly-typed, immutable abstraction.
  */
 export class NumericalValue extends PrimitiveValue {
+    static ClassName = "NumericalValue";
     readonly value: BigNumber;
     readonly sizeInBytes: number | undefined;
     readonly withSign: boolean;
@@ -103,6 +170,10 @@ export class NumericalValue extends PrimitiveValue {
         if (!this.withSign && this.value.isNegative()) {
             throw new errors.ErrInvalidArgument("value", value.toString(10), "negative, but type is unsigned");
         }
+    }
+
+    getClassName(): string {
+        return NumericalValue.ClassName;
     }
 
     /**
@@ -124,61 +195,121 @@ export class NumericalValue extends PrimitiveValue {
 }
 
 export class U8Value extends NumericalValue {
+    static ClassName = "U8Value";
+
     constructor(value: BigNumber.Value) {
         super(new U8Type(), new BigNumber(value));
+    }
+
+    getClassName(): string {
+        return U8Value.ClassName;
     }
 }
 
 export class I8Value extends NumericalValue {
+    static ClassName = "I8Value";
+
     constructor(value: BigNumber.Value) {
         super(new I8Type(), new BigNumber(value));
+    }
+
+    getClassName(): string {
+        return I8Value.ClassName;
     }
 }
 
 export class U16Value extends NumericalValue {
+    static ClassName = "U16Value";
+
     constructor(value: BigNumber.Value) {
         super(new U16Type(), new BigNumber(value));
+    }
+
+    getClassName(): string {
+        return U16Value.ClassName;
     }
 }
 
 export class I16Value extends NumericalValue {
+    static ClassName = "I16Value";
+
     constructor(value: BigNumber.Value) {
         super(new I16Type(), new BigNumber(value));
+    }
+
+    getClassName(): string {
+        return I16Value.ClassName;
     }
 }
 
 export class U32Value extends NumericalValue {
+    static ClassName = "U32Value";
+
     constructor(value: BigNumber.Value) {
         super(new U32Type(), new BigNumber(value));
+    }
+
+    getClassName(): string {
+        return U32Value.ClassName;
     }
 }
 
 export class I32Value extends NumericalValue {
+    static ClassName = "I32Value";
+
     constructor(value: BigNumber.Value) {
         super(new I32Type(), new BigNumber(value));
+    }
+
+    getClassName(): string {
+        return I32Value.ClassName;
     }
 }
 
 export class U64Value extends NumericalValue {
+    static ClassName = "U64Value";
+
     constructor(value: BigNumber.Value) {
         super(new U64Type(), value);
+    }
+
+    getClassName(): string {
+        return U64Value.ClassName;
     }
 }
 
 export class I64Value extends NumericalValue {
+    static ClassName = "I64Value";
+
     constructor(value: BigNumber.Value) {
         super(new I64Type(), value);
+    }
+
+    getClassName(): string {
+        return I64Value.ClassName;
     }
 }
 
 export class BigUIntValue extends NumericalValue {
+    static ClassName = "BigUIntValue";
+
     constructor(value: BigNumber.Value) {
         super(new BigUIntType(), value);
+    }
+
+    getClassName(): string {
+        return BigUIntValue.ClassName;
     }
 }
 
 export class BigIntValue extends NumericalValue {
+    static ClassName = "BigIntValue";
+
     constructor(value: BigNumber.Value) {
         super(new BigIntType(), value);
+    }
+
+    getClassName(): string {
+        return BigIntValue.ClassName;
     }
 }

--- a/src/smartcontracts/typesystem/string.ts
+++ b/src/smartcontracts/typesystem/string.ts
@@ -1,17 +1,28 @@
 import { PrimitiveType, PrimitiveValue } from "./types";
 
 export class StringType extends PrimitiveType {
+    static ClassName = "StringType";
+
     constructor() {
         super("utf-8 string");
+    }
+
+    getClassName(): string {
+        return StringType.ClassName;
     }
 }
 
 export class StringValue extends PrimitiveValue {
+    static ClassName = "StringValue";
     private readonly value: string;
 
     constructor(value: string) {
         super(new StringType());
         this.value = value;
+    }
+
+    getClassName(): string {
+        return StringValue.ClassName;
     }
 
     /**

--- a/src/smartcontracts/typesystem/struct.ts
+++ b/src/smartcontracts/typesystem/struct.ts
@@ -2,11 +2,16 @@ import { FieldDefinition, Field, Fields } from "./fields";
 import { CustomType, TypedValue } from "./types";
 
 export class StructType extends CustomType {
+    static ClassName = "StructType";
     private readonly fieldsDefinitions: FieldDefinition[] = [];
 
     constructor(name: string, fieldsDefinitions: FieldDefinition[]) {
         super(name);
         this.fieldsDefinitions = fieldsDefinitions;
+    }
+
+    getClassName(): string {
+        return StructType.ClassName;
     }
 
     static fromJSON(json: { name: string, fields: any[] }): StructType {
@@ -22,6 +27,7 @@ export class StructType extends CustomType {
 // TODO: implement setField(), convenience method.
 // TODO: Hold fields in a map (by name), and use the order within "field definitions" to perform codec operations.
 export class Struct extends TypedValue {
+    static ClassName = "Struct";
     private readonly fields: Field[] = [];
 
     /**
@@ -32,6 +38,10 @@ export class Struct extends TypedValue {
         this.fields = fields;
 
         this.checkTyping();
+    }
+
+    getClassName(): string {
+        return Struct.ClassName;
     }
 
     private checkTyping() {

--- a/src/smartcontracts/typesystem/tokenIdentifier.ts
+++ b/src/smartcontracts/typesystem/tokenIdentifier.ts
@@ -1,18 +1,28 @@
-import * as errors from "../../errors";
 import { PrimitiveType, PrimitiveValue } from "./types";
 
 export class TokenIdentifierType extends PrimitiveType {
+    static ClassName = "TokenIdentifierType";
+
     constructor() {
         super("TokenIdentifier");
+    }
+
+    getClassName(): string {
+        return TokenIdentifierType.ClassName;
     }
 }
 
 export class TokenIdentifierValue extends PrimitiveValue {
+    static ClassName = "TokenIdentifierValue";
     private readonly value: Buffer;
 
     constructor(value: Buffer) {
         super(new TokenIdentifierType());
         this.value = value;
+    }
+
+    getClassName(): string {
+        return TokenIdentifierValue.ClassName;
     }
 
     getLength(): number {

--- a/src/smartcontracts/typesystem/tuple.ts
+++ b/src/smartcontracts/typesystem/tuple.ts
@@ -5,8 +5,14 @@ import { Type, TypedValue } from "./types";
 import { StructType } from "./struct";
 
 export class TupleType extends StructType {
+    static ClassName = "TupleType";
+    
     constructor(...typeParameters: Type[]) {
         super(TupleType.prepareName(typeParameters), TupleType.prepareFieldDefinitions(typeParameters));
+    }
+
+    getClassName(): string {
+        return TupleType.ClassName;
     }
 
     private static prepareName(typeParameters: Type[]): string {
@@ -29,8 +35,14 @@ function prepareFieldName(fieldIndex: number) {
 // Or let Tuple be the base class, but have Struct as a specialization of it, "named tuple"?
 // Or leave as it is?
 export class Tuple extends Struct {
+    static ClassName = "Tuple";
+
     constructor(type: TupleType, fields: Field[]) {
         super(type, fields);
+    }
+
+    getClassName(): string {
+        return Tuple.ClassName;
     }
 
     static fromItems(items: TypedValue[]): Tuple {

--- a/src/smartcontracts/typesystem/typeMapper.ts
+++ b/src/smartcontracts/typesystem/typeMapper.ts
@@ -100,12 +100,12 @@ export class TypeMapper {
     mapRecursiveType(type: Type): Type | null {
         let isGeneric = type.isGenericType();
 
-        if (type.hasJavascriptConstructor(EnumType.name)) {
+        if (type.hasExactClass(EnumType.ClassName)) {
             // This will call mapType() recursively, for all the enum variant fields.
             return this.mapEnumType(<EnumType>type);
         }
 
-        if (type.hasJavascriptConstructor(StructType.name)) {
+        if (type.hasExactClass(StructType.ClassName)) {
             // This will call mapType() recursively, for all the struct's fields.
             return this.mapStructType(<StructType>type);
         }

--- a/src/smartcontracts/typesystem/types.spec.ts
+++ b/src/smartcontracts/typesystem/types.spec.ts
@@ -7,7 +7,7 @@ import { AddressType } from "./address";
 import { OptionType } from "./generic";
 import { TypeExpressionParser } from "./typeExpressionParser";
 import BigNumber from "bignumber.js";
-import { BytesType} from "./bytes";
+import { BytesType, BytesValue} from "./bytes";
 import { StringType } from "./string";
 
 describe("test types", () => {
@@ -18,7 +18,7 @@ describe("test types", () => {
         assert.throw(() => new NumericalValue(new U16Type(), <any>{ foobar: 42 }), errors.ErrInvalidArgument);
     });
 
-    it("should report type hierarchy", () => {
+    it("should be assignable from", () => {
         assert.isTrue((new Type("Type")).isAssignableFrom(new PrimitiveType("PrimitiveType")));
         assert.isTrue((new Type("Type")).isAssignableFrom(new BooleanType()));
         assert.isTrue((new Type("Type")).isAssignableFrom(new AddressType()));
@@ -57,5 +57,13 @@ describe("test types", () => {
         assert.equal(parser.parse("MultiResultVec<u32>").getFullyQualifiedName(), "erdjs:types:MultiResultVec<erdjs:types:u32>");
         assert.equal(parser.parse("utf-8 string").getFullyQualifiedName(), "erdjs:types:utf-8 string");
         assert.equal(parser.parse("Option<u32>").getFullyQualifiedName(), "erdjs:types:Option<erdjs:types:u32>");
+    });
+
+    it("types and values should have correct JavaScript class hierarchy", () => {
+        assert.deepEqual(new U32Type().getClassHierarchy(), ["Type", "PrimitiveType", "NumericalType", "U32Type"]);
+        assert.deepEqual(new U32Value(42).getClassHierarchy(), ["TypedValue", "PrimitiveValue", "NumericalValue", "U32Value"]);
+
+        assert.deepEqual(new BytesType().getClassHierarchy(), ["Type", "PrimitiveType", "BytesType"]);
+        assert.deepEqual(new BytesValue(Buffer.from("foobar")).getClassHierarchy(), ["TypedValue", "PrimitiveValue", "BytesValue"]);
     });
 });

--- a/src/smartcontracts/typesystem/variadic.ts
+++ b/src/smartcontracts/typesystem/variadic.ts
@@ -1,8 +1,14 @@
 import { Type, TypeCardinality, TypedValue, TypePlaceholder } from "./types";
 
 export class VariadicType extends Type {
+    static ClassName = "VariadicType";
+
     constructor(typeParameter: Type) {
         super("Variadic", [typeParameter], TypeCardinality.variable());
+    }
+
+    getClassName(): string {
+        return VariadicType.ClassName;
     }
 }
 
@@ -13,6 +19,7 @@ export class VariadicType extends Type {
  * this TypedValue behaves similar to a List.
  */
 export class VariadicValue extends TypedValue {
+    static ClassName = "VariadicValue";
     private readonly items: TypedValue[];
 
     /**
@@ -26,6 +33,10 @@ export class VariadicValue extends TypedValue {
         // TODO: assert items are of type type.getFirstTypeParameter()
 
         this.items = items;
+    }
+
+    getClassName(): string {
+        return VariadicValue.ClassName;
     }
 
     static fromItems(...items: TypedValue[]): VariadicValue {


### PR DESCRIPTION
Code minification broke type comparisons based on `constructor.name`. Here, the fix is to hardcode class names for classes within erdjs' typesystem. 

Tested with minified JS, as well (browserify's `tinyify`).

Should fix https://github.com/ElrondNetwork/elrond-sdk-erdjs/issues/161 and https://github.com/ElrondNetwork/elrond-sdk-erdjs/issues/150.

Also, related to https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/145.