### PR TITLE
Breaking change: preparatory refactoring for decoupling core objects from IProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - [Breaking change: adjustements to transaction awaitening and completion, transaction watcher](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/173)
  - [Breaking change: simplify network config / improve design - not a singleton anymore](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/176)
  - [Fix / improve results parser (better heuristics)](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/177)
+ - [Breaking change: preparatory refactoring for decoupling core objects from IProvider](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/178)
 
  **Breaking changes**
  - Removed utility functions: `transaction.awaitExecuted()`, `transaction.awaitPending()`. `TransactionWatcher` should be used directly, instead.
@@ -19,6 +20,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - Constructor of `Transaction` now requires `chainID`, as well.
  - Added `Interaction.withChainID()` - must be used before calling `buildTransaction()`.
  - Altered a bit the public interface of `TransactionEvent`, `Receipt` (renamed fields, renamed methods).
+ - Remove `transaction.getAsOnNetwork()`. One should use `provider.getTransaction()` instead.
+ - Remove `acount.sync()`. Replaced by `account.update({ nonce, balance})`.
+ - Remove `transaction.send()`. `Provider.sendTransaction()` has to be used instead.
 
 ## [10.0.0-beta.3]
  - [Extract dapp / signing providers to separate repositories](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/170)

--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ console.log(network.ChainID);
 
 ### Synchronizing an account object
 
+The following snippet fetches (from the Network) the nonce and the balance of an account, and updates the local representation of the account.
+
 ```
 let addressOfAlice = new Address("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
 let alice = new Account(addressOfAlice);
-await alice.sync(provider);
+let aliceOnNetwork = await provider.getAccount(addressOfAlice);
+alice.update(aliceOnNetwork);
 
 console.log(alice.nonce);
 console.log(alice.balance);
@@ -66,7 +69,7 @@ let tx = new Transaction({
 
 tx.setNonce(alice.nonce);
 await signer.sign(tx);
-await tx.send(provider);
+await provider.sendTransaction(tx);
 ```
 
 ### Creating Smart Contract transactions
@@ -83,7 +86,7 @@ let tx = contract.call({
 
 tx.setNonce(alice.nonce);
 await signer.sign(tx);
-await tx.send(provider);
+await provider.sendTransaction(tx);
 ```
 
 ### Querying Smart Contracts
@@ -104,9 +107,9 @@ console.log(response.returnData);
 ### Waiting for transactions to be processed
 
 ```
-await tx1.send(provider);
-await tx2.send(provider);
-await tx3.send(provider);
+await provider.sendTransaction(tx1);
+await provider.sendTransaction(tx2);
+await provider.sendTransaction(tx3);
 
 let watcher = new TransactionWatcher(provider);
 await Promise.all([watcher.awaitCompleted(tx1), watcher.awaitCompleted(tx2), watcher.awaitCompleted(tx3)]);
@@ -115,7 +118,8 @@ await Promise.all([watcher.awaitCompleted(tx1), watcher.awaitCompleted(tx2), wat
 ### Managing the sender nonce locally
 
 ```
-await alice.sync(provider);
+let aliceOnNetwork = await provider.getAccount(alice.address);
+alice.update(aliceOnNetwork);
 
 txA.setNonce(alice.nonce);
 alice.incrementNonce();
@@ -125,8 +129,8 @@ alice.incrementNonce();
 await signer.sign(txA);
 await signer.sign(txB);
 
-await txA.send(provider);
-await txB.send(provider);
+await provider.sendTransaction(txA);
+await provider.sendTransaction(txB);
 
 let watcher = new TransactionWatcher(provider);
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -24,8 +24,6 @@ export class Account {
      */
     balance: Balance = Egld("0");
 
-    private asOnNetwork: AccountOnNetwork = new AccountOnNetwork();
-
     /**
      * Creates an account object from an address
      */
@@ -34,37 +32,13 @@ export class Account {
     }
 
     /**
-     * Queries the details of the account on the Network
-     * @param provider the Network provider
-     * @param cacheLocally whether to save the query response within the object, locally
-     */
-    async getAsOnNetwork(provider: IProvider, cacheLocally: boolean = true): Promise<AccountOnNetwork> {
-        this.address.assertNotEmpty();
-
-        let response = await provider.getAccount(this.address);
-
-        if (cacheLocally) {
-            this.asOnNetwork = response;
-        }
-
-        return response;
-    }
-
-    /**
-     * Gets a previously saved query response
-     */
-    getAsOnNetworkCached(): AccountOnNetwork {
-        return this.asOnNetwork;
-    }
-
-    /**
      * Synchronizes account properties (such as nonce, balance) with the ones queried from the Network
      * @param provider the Network provider
      */
     async sync(provider: IProvider) {
-        await this.getAsOnNetwork(provider, true);
-        this.nonce = this.asOnNetwork.nonce;
-        this.balance = this.asOnNetwork.balance;
+        let response = await provider.getAccount(this.address);
+        this.nonce = response.nonce;
+        this.balance = response.balance;
     }
 
     /**

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,4 +1,3 @@
-import { IProvider } from "./interface";
 import { Address } from "./address";
 import { Nonce } from "./nonce";
 import { Balance } from "./balance";
@@ -32,13 +31,11 @@ export class Account {
     }
 
     /**
-     * Synchronizes account properties (such as nonce, balance) with the ones queried from the Network
-     * @param provider the Network provider
+     * Updates account properties (such as nonce, balance).
      */
-    async sync(provider: IProvider) {
-        let response = await provider.getAccount(this.address);
-        this.nonce = response.nonce;
-        this.balance = response.balance;
+    async update(obj: { nonce: Nonce, balance: Balance}) {
+        this.nonce = obj.nonce;
+        this.balance = obj.balance;
     }
 
     /**

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -3,7 +3,6 @@ import { ApiProvider } from "./apiProvider";
 import { BalanceBuilder, Egld } from "./balanceBuilder";
 import { ErrInvalidArgument } from "./errors";
 import { IApiProvider, IProvider } from "./interface";
-import { NetworkConfig } from "./networkConfig";
 import { ProxyProvider } from "./proxyProvider";
 import { SystemWrapper } from "./smartcontracts/wrapper";
 import { loadAndSyncTestWallets, TestWallet } from "./testutils";

--- a/src/smartcontracts/interaction.local.net.spec.ts
+++ b/src/smartcontracts/interaction.local.net.spec.ts
@@ -56,7 +56,7 @@ describe("test smart contract interactor", function () {
         // Execute, do not wait for execution
         let transaction = interaction.useThenIncrementNonceOf(alice.account).buildTransaction();
         await alice.signer.sign(transaction);
-        await transaction.send(provider);
+        await provider.sendTransaction(transaction);
         // Execute, and wait for execution
         transaction = interaction.useThenIncrementNonceOf(alice.account).buildTransaction();
         await alice.signer.sign(transaction);
@@ -112,7 +112,7 @@ describe("test smart contract interactor", function () {
         // Decrement twice. Wait for execution of the second transaction.
         let decrementTransaction = decrementInteraction.useThenIncrementNonceOf(alice.account).buildTransaction();
         await alice.signer.sign(decrementTransaction);
-        await decrementTransaction.send(provider);
+        await provider.sendTransaction(decrementTransaction);
 
         decrementTransaction = decrementInteraction.useThenIncrementNonceOf(alice.account).buildTransaction();
         await alice.signer.sign(decrementTransaction);

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -140,7 +140,7 @@ describe("test smart contract interactor", function() {
         // Execute, do not wait for execution
         let transaction = interaction.withNonce(new Nonce(0)).buildTransaction();
         await alice.signer.sign(transaction);
-        transaction.send(provider);
+        await provider.sendTransaction(transaction);
         assert.equal(transaction.getNonce().valueOf(), 0);
         assert.equal(transaction.getData().toString(), "getUltimateAnswer");
         assert.equal(
@@ -150,7 +150,7 @@ describe("test smart contract interactor", function() {
 
         transaction = interaction.withNonce(new Nonce(1)).buildTransaction();
         await alice.signer.sign(transaction);
-        await transaction.send(provider);
+        await provider.sendTransaction(transaction);
         assert.equal(transaction.getNonce().valueOf(), 1);
         assert.equal(
             transaction.getHash().toString(),
@@ -201,11 +201,11 @@ describe("test smart contract interactor", function() {
         // Decrement #1
         let decrementTransaction = decrementInteraction.withNonce(new Nonce(15)).buildTransaction();
         await alice.signer.sign(decrementTransaction);
-        decrementTransaction.send(provider);
+        await provider.sendTransaction(decrementTransaction);
         // Decrement #2
         decrementTransaction = decrementInteraction.withNonce(new Nonce(16)).buildTransaction();
         await alice.signer.sign(decrementTransaction);
-        decrementTransaction.send(provider);
+        await provider.sendTransaction(decrementTransaction);
         // Decrement #3
 
         decrementTransaction = decrementInteraction.withNonce(new Nonce(17)).buildTransaction();

--- a/src/smartcontracts/smartContract.local.net.spec.ts
+++ b/src/smartcontracts/smartContract.local.net.spec.ts
@@ -2,12 +2,11 @@ import { SmartContract } from "./smartContract";
 import { GasLimit } from "../networkParams";
 import { TransactionWatcher } from "../transactionWatcher";
 import { ContractFunction } from "./function";
-import { NetworkConfig } from "../networkConfig";
 import { loadTestWallets, TestWallet } from "../testutils/wallets";
 import { loadContractCode } from "../testutils";
 import { Logger } from "../logger";
 import { assert } from "chai";
-import { AddressValue, BigUIntType, BigUIntValue, OptionalType, OptionalValue, OptionValue, TokenIdentifierValue, U32Value } from "./typesystem";
+import { AddressValue, BigUIntValue, OptionalValue, OptionValue, TokenIdentifierValue, U32Value } from "./typesystem";
 import { decodeUnsignedNumber } from "./codec";
 import { BytesValue } from "./typesystem/bytes";
 import { chooseProxyProvider } from "../interactive";
@@ -81,12 +80,12 @@ describe("test on local testnet", function () {
         await transactionIncrement.send(provider);
 
         await watcher.awaitCompleted(transactionDeploy);
-        let transactionOnNetwork = await transactionDeploy.getAsOnNetwork(provider);
+        let transactionOnNetwork = await provider.getTransaction(transactionDeploy.getHash());
         let bundle = resultsParser.parseUntypedOutcome(transactionOnNetwork);
         assert.isTrue(bundle.returnCode.isSuccess());
 
         await watcher.awaitCompleted(transactionIncrement);
-        transactionOnNetwork = await transactionDeploy.getAsOnNetwork(provider);
+        transactionOnNetwork = await provider.getTransaction(transactionIncrement.getHash());
         bundle = resultsParser.parseUntypedOutcome(transactionOnNetwork);
         assert.isTrue(bundle.returnCode.isSuccess());
 
@@ -292,11 +291,11 @@ describe("test on local testnet", function () {
         await watcher.awaitAnyEvent(transactionStart, ["completedTxEvent"]);
 
         // Let's check the SCRs
-        let transactionOnNetwork = await transactionDeploy.getAsOnNetwork(provider);
+        let transactionOnNetwork = await provider.getTransaction(transactionDeploy.getHash());
         let bundle = resultsParser.parseUntypedOutcome(transactionOnNetwork);
         assert.isTrue(bundle.returnCode.isSuccess());
 
-        transactionOnNetwork = await transactionStart.getAsOnNetwork(provider);
+        transactionOnNetwork = await provider.getTransaction(transactionStart.getHash());
         bundle = resultsParser.parseUntypedOutcome(transactionOnNetwork);
         assert.isTrue(bundle.returnCode.isSuccess());
 

--- a/src/smartcontracts/smartContract.local.net.spec.ts
+++ b/src/smartcontracts/smartContract.local.net.spec.ts
@@ -76,8 +76,8 @@ describe("test on local testnet", function () {
         await alice.signer.sign(simulateTwo);
 
         // Broadcast & execute
-        await transactionDeploy.send(provider);
-        await transactionIncrement.send(provider);
+        await provider.sendTransaction(transactionDeploy);
+        await provider.sendTransaction(transactionIncrement);
 
         await watcher.awaitCompleted(transactionDeploy);
         let transactionOnNetwork = await provider.getTransaction(transactionDeploy.getHash());
@@ -90,8 +90,8 @@ describe("test on local testnet", function () {
         assert.isTrue(bundle.returnCode.isSuccess());
 
         // Simulate
-        Logger.trace(JSON.stringify(await simulateOne.simulate(provider), null, 4));
-        Logger.trace(JSON.stringify(await simulateTwo.simulate(provider), null, 4));
+        Logger.trace(JSON.stringify(await provider.simulateTransaction(simulateOne), null, 4));
+        Logger.trace(JSON.stringify(await provider.simulateTransaction(simulateTwo), null, 4));
     });
 
     it("counter: should deploy, call and query contract", async function () {
@@ -141,9 +141,9 @@ describe("test on local testnet", function () {
         alice.account.incrementNonce();
 
         // Broadcast & execute
-        await transactionDeploy.send(provider);
-        await transactionIncrementFirst.send(provider);
-        await transactionIncrementSecond.send(provider);
+        await provider.sendTransaction(transactionDeploy);
+        await provider.sendTransaction(transactionIncrementFirst);
+        await provider.sendTransaction(transactionIncrementSecond);
 
         await watcher.awaitCompleted(transactionDeploy);
         await watcher.awaitCompleted(transactionIncrementFirst);
@@ -203,9 +203,9 @@ describe("test on local testnet", function () {
         await alice.signer.sign(transactionMintCarol);
 
         // Broadcast & execute
-        await transactionDeploy.send(provider);
-        await transactionMintBob.send(provider);
-        await transactionMintCarol.send(provider);
+        await provider.sendTransaction(transactionDeploy);
+        await provider.sendTransaction(transactionMintBob);
+        await provider.sendTransaction(transactionMintCarol);
 
         await watcher.awaitCompleted(transactionDeploy);
         await watcher.awaitCompleted(transactionMintBob);
@@ -284,8 +284,8 @@ describe("test on local testnet", function () {
         await alice.signer.sign(transactionStart);
 
         // Broadcast & execute
-        await transactionDeploy.send(provider);
-        await transactionStart.send(provider);
+        await provider.sendTransaction(transactionDeploy);
+        await provider.sendTransaction(transactionStart);
 
         await watcher.awaitAllEvents(transactionDeploy, ["SCDeploy"]);
         await watcher.awaitAnyEvent(transactionStart, ["completedTxEvent"]);

--- a/src/smartcontracts/smartContract.spec.ts
+++ b/src/smartcontracts/smartContract.spec.ts
@@ -61,7 +61,7 @@ describe("test contract", () => {
         assert.equal(contract.getAddress().bech32(), "erd1qqqqqqqqqqqqqpgq3ytm9m8dpeud35v3us20vsafp77smqghd8ss4jtm0q");
 
         // Now let's broadcast the deploy transaction, and wait for its execution.
-        let hash = await deployTransaction.send(provider);
+        let hash = await provider.sendTransaction(deployTransaction);
 
         await Promise.all([
             provider.mockTransactionTimeline(deployTransaction, [new Wait(40), new TransactionStatus("pending"), new Wait(40), new TransactionStatus("executed"), new InHyperblock()]),
@@ -111,8 +111,8 @@ describe("test contract", () => {
         alice.signer.sign(callTransactionOne);
         alice.signer.sign(callTransactionTwo);
 
-        let hashOne = await callTransactionOne.send(provider);
-        let hashTwo = await callTransactionTwo.send(provider);
+        let hashOne = await provider.sendTransaction(callTransactionOne);
+        let hashTwo = await provider.sendTransaction(callTransactionTwo);
 
         await Promise.all([
             provider.mockTransactionTimeline(callTransactionOne, [new Wait(40), new TransactionStatus("pending"), new Wait(40), new TransactionStatus("executed"), new InHyperblock()]),

--- a/src/smartcontracts/smartContractController.ts
+++ b/src/smartcontracts/smartContractController.ts
@@ -52,7 +52,7 @@ export class SmartContractController implements ISmartContractController {
     async deploy(transaction: Transaction): Promise<{ transactionOnNetwork: TransactionOnNetwork, bundle: UntypedOutcomeBundle }> {
         Logger.info(`SmartContractController.deploy [begin]: transaction = ${transaction.getHash()}`);
 
-        await transaction.send(this.provider);
+        await this.provider.sendTransaction(transaction);
         await this.transactionCompletionAwaiter.awaitCompleted(transaction);
         let transactionOnNetwork = await this.provider.getTransaction(transaction.getHash());
         let bundle = this.parser.parseUntypedOutcome(transactionOnNetwork);
@@ -74,7 +74,7 @@ export class SmartContractController implements ISmartContractController {
 
         this.checker.checkInteraction(interaction, endpoint);
 
-        await transaction.send(this.provider);
+        await this.provider.sendTransaction(transaction);
         await this.transactionCompletionAwaiter.awaitCompleted(transaction);
         let transactionOnNetwork = await this.provider.getTransaction(transaction.getHash());
         let bundle = this.parser.parseOutcome(transactionOnNetwork, endpoint);

--- a/src/smartcontracts/smartContractController.ts
+++ b/src/smartcontracts/smartContractController.ts
@@ -54,7 +54,7 @@ export class SmartContractController implements ISmartContractController {
 
         await transaction.send(this.provider);
         await this.transactionCompletionAwaiter.awaitCompleted(transaction);
-        let transactionOnNetwork = await transaction.getAsOnNetwork(this.provider);
+        let transactionOnNetwork = await this.provider.getTransaction(transaction.getHash());
         let bundle = this.parser.parseUntypedOutcome(transactionOnNetwork);
 
         Logger.info(`SmartContractController.deploy [end]: transaction = ${transaction.getHash()}, return code = ${bundle.returnCode}`);
@@ -76,7 +76,7 @@ export class SmartContractController implements ISmartContractController {
 
         await transaction.send(this.provider);
         await this.transactionCompletionAwaiter.awaitCompleted(transaction);
-        let transactionOnNetwork = await transaction.getAsOnNetwork(this.provider);
+        let transactionOnNetwork = await this.provider.getTransaction(transaction.getHash());
         let bundle = this.parser.parseOutcome(transactionOnNetwork, endpoint);
 
         Logger.info(`SmartContractController.execute [end]: function = ${interaction.getFunction()}, transaction = ${transaction.getHash()}, return code = ${bundle.returnCode}`);

--- a/src/smartcontracts/smartContractResults.local.net.spec.ts
+++ b/src/smartcontracts/smartContractResults.local.net.spec.ts
@@ -1,4 +1,3 @@
-import { NetworkConfig } from "../networkConfig";
 import { loadContractCode, loadTestWallets, TestWallet } from "../testutils";
 import { TransactionWatcher } from "../transactionWatcher";
 import { GasLimit } from "../networkParams";
@@ -59,15 +58,13 @@ describe("fetch transactions from local testnet", function () {
         await watcher.awaitCompleted(transactionDeploy);
         await watcher.awaitCompleted(transactionIncrement);
 
-        await transactionDeploy.getAsOnNetwork(provider);
-        await transactionIncrement.getAsOnNetwork(provider);
+        let transactionOnNetworkDeploy = await provider.getTransaction(transactionDeploy.getHash());
+        let transactionOnNetworkIncrement = await provider.getTransaction(transactionIncrement.getHash());
 
-        let transactionOnNetwork = transactionDeploy.getAsOnNetworkCached();
-        let bundle = resultsParser.parseUntypedOutcome(transactionOnNetwork);
+        let bundle = resultsParser.parseUntypedOutcome(transactionOnNetworkDeploy);
         assert.isTrue(bundle.returnCode.isSuccess());
 
-        transactionOnNetwork = transactionIncrement.getAsOnNetworkCached();
-        bundle = resultsParser.parseUntypedOutcome(transactionOnNetwork);
+        bundle = resultsParser.parseUntypedOutcome(transactionOnNetworkIncrement);
         assert.isTrue(bundle.returnCode.isSuccess());
     });
 });

--- a/src/smartcontracts/smartContractResults.local.net.spec.ts
+++ b/src/smartcontracts/smartContractResults.local.net.spec.ts
@@ -52,8 +52,8 @@ describe("fetch transactions from local testnet", function () {
         alice.account.incrementNonce();
 
         // Broadcast & execute
-        await transactionDeploy.send(provider);
-        await transactionIncrement.send(provider);
+        await provider.sendTransaction(transactionDeploy);
+        await provider.sendTransaction(transactionIncrement);
 
         await watcher.awaitCompleted(transactionDeploy);
         await watcher.awaitCompleted(transactionIncrement);

--- a/src/smartcontracts/wrapper/contractWrapper.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.ts
@@ -189,7 +189,7 @@ export class ContractWrapper extends ChainSendContext {
 
         logger?.transactionSent(transaction);
         await new TransactionWatcher(provider).awaitCompleted(transaction);
-        let transactionOnNetwork = await transaction.getAsOnNetwork(provider);
+        let transactionOnNetwork = await provider.getTransaction(transaction.getHash());
         if (transactionOnNetwork.status.isFailed()) {
             // TODO: extract the error messages
             //let results = transactionOnNetwork.results.getAllResults();

--- a/src/smartcontracts/wrapper/contractWrapper.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.ts
@@ -180,7 +180,7 @@ export class ContractWrapper extends ChainSendContext {
 
         let logger = this.context.getLogger();
         logger?.transactionCreated(transaction);
-        await transaction.send(provider);
+        await provider.sendTransaction(transaction);
 
         // increment the nonce only after the transaction is sent
         // since an exception thrown by the provider means we will have to re-use the same nonce

--- a/src/smartcontracts/wrapper/contractWrapper.ts
+++ b/src/smartcontracts/wrapper/contractWrapper.ts
@@ -189,7 +189,7 @@ export class ContractWrapper extends ChainSendContext {
 
         logger?.transactionSent(transaction);
         await new TransactionWatcher(provider).awaitCompleted(transaction);
-        let transactionOnNetwork = await transaction.getAsOnNetwork(provider, true, true);
+        let transactionOnNetwork = await transaction.getAsOnNetwork(provider);
         if (transactionOnNetwork.status.isFailed()) {
             // TODO: extract the error messages
             //let results = transactionOnNetwork.results.getAllResults();

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -86,7 +86,8 @@ export class TestWallet {
     }
 
     async sync(provider: IProvider) {
-        await this.account.sync(provider);
+        let accountOnNetwork = await provider.getAccount(this.address);
+        await this.account.update(accountOnNetwork);
         return this;
     }
 }

--- a/src/transaction.local.net.spec.ts
+++ b/src/transaction.local.net.spec.ts
@@ -48,8 +48,8 @@ describe("test transaction", function () {
         await alice.signer.sign(transactionOne);
         await alice.signer.sign(transactionTwo);
 
-        await transactionOne.send(provider);
-        await transactionTwo.send(provider);
+        await provider.sendTransaction(transactionOne);
+        await provider.sendTransaction(transactionTwo);
 
         await watcher.awaitCompleted(transactionOne);
         await watcher.awaitCompleted(transactionTwo);
@@ -89,7 +89,7 @@ describe("test transaction", function () {
         await alice.signer.sign(transactionOne);
         await alice.signer.sign(transactionTwo);
 
-        Logger.trace(JSON.stringify(await transactionOne.simulate(provider), null, 4));
-        Logger.trace(JSON.stringify(await transactionTwo.simulate(provider), null, 4));
+        Logger.trace(JSON.stringify(await provider.simulateTransaction(transactionOne), null, 4));
+        Logger.trace(JSON.stringify(await provider.simulateTransaction(transactionTwo), null, 4));
     });
 });

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { IAddressOfExternalSigner, IProvider, ISignable, ISignatureOfExternalSigner, ITransactionFetcher } from "./interface";
+import { IAddressOfExternalSigner, IProvider, ISignable, ISignatureOfExternalSigner } from "./interface";
 import { Address } from "./address";
 import { Balance } from "./balance";
 import {
@@ -17,7 +17,6 @@ import { TransactionPayload } from "./transactionPayload";
 import * as errors from "./errors";
 import { TypedEvent } from "./events";
 import { ProtoSerializer } from "./proto";
-import { TransactionOnNetwork } from "./transactionOnNetwork";
 import { Hash } from "./hash";
 import { adaptToAddress, adaptToSignature } from "./boundaryAdapters";
 
@@ -338,21 +337,6 @@ export class Transaction implements ISignable {
     }
 
     return this.toPlainObject();
-  }
-
-  /**
-   * Fetches a representation of the transaction (whether pending, processed or finalized), as found on the Network.
-   *
-   * @param fetcher The transaction fetcher to use
-   */
-  async getAsOnNetwork(fetcher: ITransactionFetcher): Promise<TransactionOnNetwork> {
-    let response = await fetcher.getTransaction(
-      this.hash,
-      this.sender,
-      true
-    );
-
-    return response;
   }
 
   async awaitSigned(): Promise<void> {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -142,7 +142,8 @@ export class Transaction implements ISignable {
    * Sets the account sequence number of the sender. Must be done prior signing.
    *
    * ```
-   * await alice.sync(provider);
+   * let aliceOnNetwork = await provider.getAccount(alice.address);
+   * alice.update(aliceOnNetwork);
    *
    * let tx = new Transaction({
    *      value: Balance.egld(1),
@@ -305,31 +306,8 @@ export class Transaction implements ISignable {
   }
 
   /**
-   * Broadcasts a transaction to the Network, via a {@link IProvider}.
-   *
-   * ```
-   * let provider = new ProxyProvider("https://gateway.elrond.com");
-   * let watcher = new TransactionWatcher(provider);
-   * // ... Prepare, sign the transaction, then:
-   * await tx.send(provider);
-   * await watcher.awaitCompleted(tx);
-   * ```
-   */
-  async send(provider: IProvider): Promise<TransactionHash> {
-    this.hash = await provider.sendTransaction(this);
-    return this.hash;
-  }
-
-  /**
-   * Simulates a transaction on the Network, via a {@link IProvider}.
-   */
-  async simulate(provider: IProvider): Promise<any> {
-    return await provider.simulateTransaction(this);
-  }
-
-  /**
    * Converts a transaction to a ready-to-broadcast object.
-   * Called internally by the {@link IProvider}.
+   * Called internally by the network provider.
    */
   toSendable(): any {
     if (this.signature.isEmpty()) {


### PR DESCRIPTION
Decoupled `account` and `transaction` from `IProvider`.

 - Remove `transaction.getAsOnNetwork()`. One should use `provider.getTransaction()` instead.
 - Remove `acount.sync()`. Replaced by `account.update({ nonce, balance})`.
 - Remove `transaction.send()`. `Provider.sendTransaction()` has to be used instead.