### PR TITLE
Breaking change: decouple networkStake, networkStatus and stats from IProvider & IApiProvider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - [Breaking change: simplify network config / improve design - not a singleton anymore](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/176)
  - [Fix / improve results parser (better heuristics)](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/177)
  - [Breaking change: preparatory refactoring for decoupling core objects from IProvider](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/178)
+ - [Breaking change: decouple networkStake, networkStatus and stats from IProvider & IApiProvider](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/179)
 
  **Breaking changes**
  - Removed utility functions: `transaction.awaitExecuted()`, `transaction.awaitPending()`. `TransactionWatcher` should be used directly, instead.
@@ -20,9 +21,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - Constructor of `Transaction` now requires `chainID`, as well.
  - Added `Interaction.withChainID()` - must be used before calling `buildTransaction()`.
  - Altered a bit the public interface of `TransactionEvent`, `Receipt` (renamed fields, renamed methods).
- - Remove `transaction.getAsOnNetwork()`. One should use `provider.getTransaction()` instead.
- - Remove `acount.sync()`. Replaced by `account.update({ nonce, balance})`.
- - Remove `transaction.send()`. `Provider.sendTransaction()` has to be used instead.
+ - Removed `transaction.getAsOnNetwork()`. One should use `provider.getTransaction()` instead.
+ - Removed `acount.sync()`. Replaced by `account.update({ nonce, balance})`.
+ - Removed `transaction.send()`. `Provider.sendTransaction()` has to be used instead.
+ - Removed the static functions `getDefault()` and `sync()` from `networkStake`, `networkStatus` and `stats`.
 
 ## [10.0.0-beta.3]
  - [Extract dapp / signing providers to separate repositories](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/170)

--- a/src/networkStake.ts
+++ b/src/networkStake.ts
@@ -1,4 +1,3 @@
-import { IApiProvider } from "./interface";
 import BigNumber from "bignumber.js";
 
 /**
@@ -30,26 +29,6 @@ export class NetworkStake {
     this.ActiveValidators = 0;
     this.QueueSize = 0;
     this.TotalStaked = new BigNumber(0);
-  }
-
-  /**
-   * Gets the default configuration object (think of the Singleton pattern).
-   */
-  static getDefault(): NetworkStake {
-    if (!NetworkStake.default) {
-      NetworkStake.default = new NetworkStake();
-    }
-
-    return NetworkStake.default;
-  }
-
-  /**
-   * Synchronizes a configuration object by querying the Network, through a {@link IProvider}.
-   * @param provider The provider to use
-   */
-  async sync(provider: IApiProvider): Promise<void> {
-    let fresh: NetworkStake = await provider.getNetworkStake();
-    Object.assign(this, fresh);
   }
 
   /**

--- a/src/networkStatus.ts
+++ b/src/networkStatus.ts
@@ -1,5 +1,3 @@
-import { IProvider } from "./interface";
-
 /**
  * An object holding network status configuration parameters.
  */
@@ -61,26 +59,6 @@ export class NetworkStatus {
         this.RoundAtEpochStart = 0;
         this.RoundsPassedInCurrentEpoch = 0;
         this.RoundsPerEpoch = 0;
-    }
-
-    /**
-     * Gets the default network status object (think of the Singleton pattern).
-     */
-    static getDefault(): NetworkStatus {
-        if (!NetworkStatus.default) {
-            NetworkStatus.default = new NetworkStatus();
-        }
-
-        return NetworkStatus.default;
-    }
-
-    /**
-     * Synchronizes a configuration object by querying the node, through a {@link IProvider}.
-     * @param provider The provider to use
-     */
-    async sync(provider: IProvider): Promise<void> {
-        let fresh: NetworkStatus = await provider.getNetworkStatus();
-        Object.assign(this, fresh);
     }
 
     /**

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,5 +1,3 @@
-import { IApiProvider } from "./interface";
-
 /**
  * An object holding Network stats parameters.
  */
@@ -49,15 +47,6 @@ export class Stats {
         this.Epoch = 0;
         this.RoundsPassed = 0;
         this.RoundsPerEpoch = 0;
-    }
-
-    /**
-     * Synchronizes a stats object by querying the Network, through a {@link IProvider}.
-     * @param provider The provider to use
-     */
-    async sync(provider: IApiProvider): Promise<void> {
-        let fresh: Stats = await provider.getNetworkStats();
-        Object.assign(this, fresh);
     }
 
     /**

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { IAddressOfExternalSigner, IProvider, ISignable, ISignatureOfExternalSigner } from "./interface";
+import { IAddressOfExternalSigner, ISignable, ISignatureOfExternalSigner } from "./interface";
 import { Address } from "./address";
 import { Balance } from "./balance";
 import {


### PR DESCRIPTION
Removed the static functions `getDefault()` and `sync()` from `networkStake`, `networkStatus` and `stats`.