### PR TITLE
Breaking change: unifying provider interfaces, preparing network providers for extraction - step 2

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -2,7 +2,7 @@ import { Address } from "./address";
 import { Nonce } from "./nonce";
 import { Balance } from "./balance";
 import { Egld } from "./balanceBuilder";
-import BigNumber from "bignumber.js";
+import { IAccountBalance, INonce } from "./interface";
 
 /**
  * An abstraction representing an account (user or Smart Contract) on the Network.
@@ -33,9 +33,9 @@ export class Account {
     /**
      * Updates account properties (such as nonce, balance).
      */
-    async update(obj: { nonce: Nonce, balance: Balance}) {
-        this.nonce = obj.nonce;
-        this.balance = obj.balance;
+    async update(obj: { nonce: INonce, balance: IAccountBalance}) {
+        this.nonce = new Nonce(obj.nonce.valueOf());
+        this.balance = Balance.fromString(obj.balance.toString());
     }
 
     /**
@@ -63,54 +63,5 @@ export class Account {
             nonce: this.nonce.valueOf(),
             balance: this.balance.toString(),
         };
-    }
-}
-
-/**
- * A plain view of an account, as queried from the Network.
- */
-export class AccountOnNetwork {
-    address: Address = new Address();
-    nonce: Nonce = new Nonce(0);
-    balance: Balance = Egld(0);
-    code: string = "";
-    userName: string = "";
-
-    constructor(init?: Partial<AccountOnNetwork>) {
-        Object.assign(this, init);
-    }
-
-    static fromHttpResponse(payload: any): AccountOnNetwork {
-        let result = new AccountOnNetwork();
-
-        result.address = new Address(payload["address"] || 0);
-        result.nonce = new Nonce(payload["nonce"] || 0);
-        result.balance = Balance.fromString(payload["balance"] || "0");
-        result.code = payload["code"] || "";
-        result.userName = payload["username"] || "";
-
-        return result;
-    }
-}
-
-export class TokenOfAccountOnNetwork {
-    tokenIdentifier: string = "";
-    attributes: Buffer = Buffer.from([]);
-    balance: BigNumber = new BigNumber(0);
-    nonce: Nonce = new Nonce(0);
-    creator: Address = new Address("");
-    royalties: BigNumber = new BigNumber(0);
-
-    static fromHttpResponse(payload: any): TokenOfAccountOnNetwork {
-        let result = new TokenOfAccountOnNetwork();
-
-        result.tokenIdentifier = payload.tokenIdentifier;
-        result.attributes = Buffer.from(payload.attributes || "", "base64");
-        result.balance = new BigNumber(payload.balance || 0);
-        result.nonce = new Nonce(payload.nonce || 0);
-        result.creator = new Address(payload.creator || "");
-        result.royalties = new BigNumber(payload.royalties || 0);
-
-        return result;
     }
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,7 +1,6 @@
 import { Transaction } from "./transaction";
 import { NetworkConfig } from "./networkConfig";
 import { Signature } from "./signature";
-import { AccountOnNetwork, TokenOfAccountOnNetwork } from "./account";
 import { Query } from "./smartcontracts";
 import { QueryResponse } from "./smartcontracts";
 import { NetworkStake } from "./networkStake";
@@ -9,7 +8,7 @@ import { Stats } from "./stats";
 import { NetworkStatus } from "./networkStatus";
 import { Token } from "./token";
 import BigNumber from "bignumber.js";
-import { ITransactionOnNetwork, ITransactionStatus } from "./interfaceOfNetwork";
+import { IAccountOnNetwork, IFungibleTokenOfAccountOnNetwork, ITransactionOnNetwork, ITransactionStatus } from "./interfaceOfNetwork";
 
 export interface ITransactionFetcher {
     /**
@@ -40,12 +39,12 @@ export interface IProvider extends ITransactionFetcher {
     /**
      * Fetches the state of an {@link Account}.
      */
-    getAccount(address: IBech32Address): Promise<AccountOnNetwork>;
+    getAccount(address: IBech32Address): Promise<IAccountOnNetwork>;
 
     /**
      * Fetches the list of ESDT data for all the tokens of an address.
      */
-    getAddressEsdtList(address: IBech32Address): Promise<TokenOfAccountOnNetwork[]>;
+    getAddressEsdtList(address: IBech32Address): Promise<IFungibleTokenOfAccountOnNetwork[]>;
 
     /**
      * Fetches the ESDT data for a token of an address.
@@ -147,5 +146,6 @@ export interface ISignature { hex(): string; }
 export interface IHash { hex(): string; }
 export interface IBech32Address { bech32(): string; }
 export interface ITransactionValue { toString(): string; }
+export interface IAccountBalance { toString(): string; }
 export interface ITransactionPayload { encoded(): string; }
 export interface INonce { valueOf(): number; }

--- a/src/interfaceOfNetwork.ts
+++ b/src/interfaceOfNetwork.ts
@@ -1,4 +1,15 @@
-import { IBech32Address, IHash, INonce, ITransactionPayload, ITransactionValue } from "./interface";
+import { IAccountBalance, IBech32Address, IHash, INonce, ITransactionPayload, ITransactionValue } from "./interface";
+
+export interface IAccountOnNetwork {
+    nonce: INonce;
+    balance: IAccountBalance;
+}
+
+/**
+ * @deprecated This interface will be removed upon the extraction of networkProvider package.
+ */
+export interface IFungibleTokenOfAccountOnNetwork {
+}
 
 export interface ITransactionOnNetwork {
     hash: IHash;

--- a/src/interfaceOfNetwork.ts
+++ b/src/interfaceOfNetwork.ts
@@ -1,5 +1,8 @@
 import { IAccountBalance, IBech32Address, IHash, INonce, ITransactionPayload, ITransactionValue } from "./interface";
 
+/**
+ * @deprecated This interface will be removed upon the extraction of networkProvider package.
+ */
 export interface IAccountOnNetwork {
     nonce: INonce;
     balance: IAccountBalance;

--- a/src/networkProvider/accounts.ts
+++ b/src/networkProvider/accounts.ts
@@ -1,0 +1,30 @@
+import { IAccountBalance, IAddress, INonce } from "./interface";
+import { AccountBalance, Address, Nonce } from "./primitives";
+
+/**
+ * A plain view of an account, as queried from the Network.
+ */
+ export class AccountOnNetwork {
+    address: IAddress = new Address("");
+    nonce: INonce = new Nonce(0);
+    balance: IAccountBalance = new AccountBalance("");
+    code: string = "";
+    userName: string = "";
+
+    constructor(init?: Partial<AccountOnNetwork>) {
+        Object.assign(this, init);
+    }
+
+    static fromHttpResponse(payload: any): AccountOnNetwork {
+        let result = new AccountOnNetwork();
+
+        result.address = new Address(payload["address"] || 0);
+        result.nonce = new Nonce(payload["nonce"] || 0);
+        result.balance = new AccountBalance(payload["balance"] || "0");
+        result.code = payload["code"] || "";
+        result.userName = payload["username"] || "";
+
+        return result;
+    }
+}
+

--- a/src/networkProvider/apiNetworkProvider.ts
+++ b/src/networkProvider/apiNetworkProvider.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from "axios";
-import { AccountOnNetwork } from "../account";
+import { AccountOnNetwork } from "./accounts";
 import { IAddress, IContractQueryResponse, IDefinitionOfFungibleTokenOnNetwork, IDefinitionOfTokenCollectionOnNetwork, IFungibleTokenOfAccountOnNetwork, IHash, INetworkProvider, INonce, INonFungibleTokenOfAccountOnNetwork, ITransaction, Pagination } from "./interface";
 import { NetworkConfig } from "../networkConfig";
 import { NetworkStake } from "../networkStake";

--- a/src/networkProvider/interface.ts
+++ b/src/networkProvider/interface.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { AccountOnNetwork } from "../account";
+import { AccountOnNetwork } from "./accounts";
 import { NetworkConfig } from "../networkConfig";
 import { NetworkStake } from "../networkStake";
 import { NetworkStatus } from "../networkStatus";
@@ -195,3 +195,4 @@ export interface INonce extends IHexable { valueOf(): number; }
 export interface ITransactionPayload { encoded(): string; }
 export interface IGasLimit { valueOf(): number; }
 export interface IGasPrice { valueOf(): number; }
+export interface IAccountBalance { toString(): string; }

--- a/src/networkProvider/primitives.ts
+++ b/src/networkProvider/primitives.ts
@@ -80,6 +80,18 @@ export class ContractReturnCode {
     }
 }
 
+export class AccountBalance {
+    private readonly value: string;
+
+    constructor(value: string) {
+        this.value = value;
+    }
+
+    toString(): string {
+        return this.value;
+    }
+}
+
 export function numberToPaddedHex(value: number) {
     let hex = value.toString(16);
     return zeroPadStringIfOddLength(hex);

--- a/src/networkProvider/proxyNetworkProvider.ts
+++ b/src/networkProvider/proxyNetworkProvider.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from "axios";
-import { AccountOnNetwork } from "../account";
+import { AccountOnNetwork } from "./accounts";
 import { IAddress, IContractQueryResponse, IDefinitionOfFungibleTokenOnNetwork, IDefinitionOfTokenCollectionOnNetwork, IFungibleTokenOfAccountOnNetwork, IHash, INetworkProvider, INonce, INonFungibleTokenOfAccountOnNetwork, ITransaction, Pagination } from "./interface";
 import { NetworkConfig } from "../networkConfig";
 import { NetworkStake } from "../networkStake";

--- a/src/proxyProvider.ts
+++ b/src/proxyProvider.ts
@@ -6,14 +6,13 @@ import { Transaction, TransactionHash } from "./transaction";
 import { NetworkConfig } from "./networkConfig";
 import { Address } from "./address";
 import * as errors from "./errors";
-import { AccountOnNetwork, TokenOfAccountOnNetwork } from "./account";
 import { Query } from "./smartcontracts/query";
 import { QueryResponse } from "./smartcontracts/queryResponse";
 import { Logger } from "./logger";
 import { NetworkStatus } from "./networkStatus";
 import { defaultConfig } from "./constants";
 import { ProxyNetworkProvider } from "./networkProvider/proxyNetworkProvider";
-import { ITransactionOnNetwork, ITransactionStatus } from "./interfaceOfNetwork";
+import { IAccountOnNetwork, IFungibleTokenOfAccountOnNetwork, ITransactionOnNetwork, ITransactionStatus } from "./interfaceOfNetwork";
 
 /**
  * This will be deprecated once all the endpoints move to ApiProvider
@@ -40,19 +39,14 @@ export class ProxyProvider implements IProvider {
     }
 
     /**
-     * Fetches the state of an {@link Account}.
+     * Fetches the state of an account.
      */
-    async getAccount(address: Address): Promise<AccountOnNetwork> {
-        return this.doGetGeneric(`address/${address.bech32()}`, (response) =>
-            AccountOnNetwork.fromHttpResponse(response.account)
-        );
+    async getAccount(address: Address): Promise<IAccountOnNetwork> {
+        return await this.backingProvider.getAccount(address);
     }
 
-    async getAddressEsdtList(address: Address): Promise<TokenOfAccountOnNetwork[]> {
-        let url = `address/${address.bech32()}/esdt`;
-        let raw = await this.doGetGeneric(url, response => response.esdts);
-        let tokens = Object.values(raw).map(item => TokenOfAccountOnNetwork.fromHttpResponse(item));
-        return tokens;
+    async getAddressEsdtList(address: Address): Promise<IFungibleTokenOfAccountOnNetwork[]> {
+        return await this.backingProvider.getFungibleTokensOfAccount(address);
     }
 
     async getAddressEsdt(address: Address, tokenIdentifier: string): Promise<any> {

--- a/src/smartcontracts/wrapper/systemWrapper.ts
+++ b/src/smartcontracts/wrapper/systemWrapper.ts
@@ -119,7 +119,9 @@ export class SystemWrapper extends ChainSendContext {
     async getBalance(address: NativeTypes.NativeAddress, balanceBuilder: BalanceBuilder): Promise<Balance> {
         let typedAddress = NativeSerializer.convertNativeToAddress(address, new ArgumentErrorContext("getBalance", "0", new EndpointParameterDefinition("account", "", new AddressType())));
         if (balanceBuilder.getToken().isEgld()) {
-            return await this.provider.getAccount(typedAddress).then((account) => account.balance);
+            let account = await this.provider.getAccount(typedAddress);
+            let balance = Balance.fromString(account.balance.toString());
+            return balance;
         }
         let tokenData = await this.getTokenData(typedAddress, balanceBuilder);
         return balanceBuilder.raw(tokenData.balance);

--- a/src/testutils/mockProvider.ts
+++ b/src/testutils/mockProvider.ts
@@ -4,7 +4,6 @@ import { NetworkConfig } from "../networkConfig";
 import { Address } from "../address";
 import { Nonce } from "../nonce";
 import { AsyncTimer } from "../asyncTimer";
-import { AccountOnNetwork } from "../account";
 import { Balance } from "../balance";
 import * as errors from "../errors";
 import { Query } from "../smartcontracts/query";
@@ -17,6 +16,7 @@ import { ContractResultItem, ContractResults } from "../networkProvider/contract
 import { TransactionOnNetwork } from "../networkProvider/transactions";
 import { ITransactionOnNetwork, ITransactionStatus } from "../interfaceOfNetwork";
 import { TransactionStatus } from "../networkProvider/transactionStatus";
+import { AccountOnNetwork } from "../networkProvider/accounts";
 
 const DummyHyperblockNonce = 42;
 const DummyHyperblockHash = "a".repeat(32);


### PR DESCRIPTION
Second part of decoupling `src/networkProvider` from erdjs components: move `accountOnNetwork` to `networkProvider`.



When decoupling is done, no file within `src/networkProvider` should reference files from other packages. Then, we can extract `networkProvider` to a separate repository and continue the interface reconciliation process (API & Proxy).