### PR TITLE
Breaking change: SmartContract does not depend on IProvider anymore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - [Fix / improve results parser (better heuristics)](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/177)
  - [Breaking change: preparatory refactoring for decoupling core objects from IProvider](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/178)
  - [Breaking change: decouple networkStake, networkStatus and stats from IProvider & IApiProvider](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/179)
+ - [Breaking change: unifying provider interfaces, preparing network providers for extraction - step 1](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/180)
+ - [Breaking change: unifying provider interfaces, preparing network providers for extraction - step 2](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/181)
+ - [Breaking change: unifying provider interfaces, preparing network providers for extraction - step 3](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/182)
+ - [Breaking change: SmartContract does not depend on IProvider anymore](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/183).
 
  **Breaking changes**
  - Removed utility functions: `transaction.awaitExecuted()`, `transaction.awaitPending()`. `TransactionWatcher` should be used directly, instead.
@@ -25,6 +29,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - Removed `acount.sync()`. Replaced by `account.update({ nonce, balance})`.
  - Removed `transaction.send()`. `Provider.sendTransaction()` has to be used instead.
  - Removed the static functions `getDefault()` and `sync()` from `networkStake`, `networkStatus` and `stats`.
+ - Removed `smartContract.runQuery()` in order to decouple the contract class from the network provider. `smartContract.createQuery()` + `provider.queryContract()` have to be used, instead.
 
 ## [10.0.0-beta.3]
  - [Extract dapp / signing providers to separate repositories](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/170)

--- a/src/smartcontracts/query.main.net.spec.ts
+++ b/src/smartcontracts/query.main.net.spec.ts
@@ -2,7 +2,6 @@ import { assert } from "chai";
 import { Address } from "../address";
 import { ContractFunction } from "./function";
 import { SmartContract } from "./smartContract";
-import * as errors from "../errors";
 import { AddressValue } from "./typesystem";
 import { chooseProxyProvider } from "../interactive";
 
@@ -11,18 +10,22 @@ describe("test queries on mainnet", function () {
     let delegationContract = new SmartContract({ address: new Address("erd1qqqqqqqqqqqqqpgqxwakt2g7u9atsnr03gqcgmhcv38pt7mkd94q6shuwt") });
 
     it("delegation: should getTotalStakeByType", async () => {
-        let response = await delegationContract.runQuery(provider, {
+        let query = delegationContract.createQuery({
             func: new ContractFunction("getTotalStakeByType")
         });
+
+        let response = await provider.queryContract(query);
 
         assert.isTrue(response.isSuccess());
         assert.lengthOf(response.returnData, 5);
     });
 
     it("delegation: should getNumUsers", async () => {
-        let response = await delegationContract.runQuery(provider, {
+        let query = delegationContract.createQuery({
             func: new ContractFunction("getNumUsers")
         });
+
+        let response = await provider.queryContract(query);
 
         assert.isTrue(response.isSuccess());
         assert.lengthOf(response.returnData, 1);
@@ -33,9 +36,11 @@ describe("test queries on mainnet", function () {
     it("delegation: should getFullWaitingList", async function () {
         this.timeout(20000);
 
-        let response = await delegationContract.runQuery(provider, {
+        let query = delegationContract.createQuery({
             func: new ContractFunction("getFullWaitingList")
         });
+
+        let response = await provider.queryContract(query);
 
         assert.isTrue(response.isSuccess());
         assert.isAtLeast(response.returnData.length, 42);
@@ -45,18 +50,22 @@ describe("test queries on mainnet", function () {
         this.timeout(5000);
 
         // First, expect an error (bad arguments):
-        let response = await delegationContract.runQuery(provider, {
+        let query = delegationContract.createQuery({
             func: new ContractFunction("getClaimableRewards")
         });
+
+        let response = await provider.queryContract(query);
 
         assert.include(response.returnCode.toString(), "user error");
         assert.include(response.returnMessage, "wrong number of arguments");
 
         // Then do a successful query:
-        response = await delegationContract.runQuery(provider, {
+        query = delegationContract.createQuery({
             func: new ContractFunction("getClaimableRewards"),
             args: [new AddressValue(new Address("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"))]
         });
+
+        response = await provider.queryContract(query);
 
         assert.isTrue(response.isSuccess());
         assert.isAtLeast(response.returnData.length, 1);

--- a/src/smartcontracts/smartContract.local.net.spec.ts
+++ b/src/smartcontracts/smartContract.local.net.spec.ts
@@ -150,7 +150,8 @@ describe("test on local testnet", function () {
         await watcher.awaitCompleted(transactionIncrementSecond);
 
         // Check counter
-        let queryResponse = await contract.runQuery(provider, { func: new ContractFunction("get") });
+        let query = contract.createQuery({ func: new ContractFunction("get") });
+        let queryResponse = await provider.queryContract(query);
         assert.equal(3, decodeUnsignedNumber(queryResponse.getReturnDataParts()[0]));
     });
 
@@ -212,27 +213,32 @@ describe("test on local testnet", function () {
         await watcher.awaitCompleted(transactionMintCarol);
 
         // Query state, do some assertions
-        let queryResponse = await contract.runQuery(provider, {
-            func: new ContractFunction("totalSupply")
-        });
+        let query = contract.createQuery({ func: new ContractFunction("totalSupply") });
+        let queryResponse = await provider.queryContract(query);
         assert.equal(10000, decodeUnsignedNumber(queryResponse.getReturnDataParts()[0]));
 
-        queryResponse = await contract.runQuery(provider, {
+        query = contract.createQuery({
             func: new ContractFunction("balanceOf"),
             args: [new AddressValue(alice.address)]
         });
+        queryResponse = await provider.queryContract(query);
+
         assert.equal(7500, decodeUnsignedNumber(queryResponse.getReturnDataParts()[0]));
 
-        queryResponse = await contract.runQuery(provider, {
+        query = contract.createQuery({
             func: new ContractFunction("balanceOf"),
             args: [new AddressValue(bob.address)]
         });
+        queryResponse = await provider.queryContract(query);
+
         assert.equal(1000, decodeUnsignedNumber(queryResponse.getReturnDataParts()[0]));
 
-        queryResponse = await contract.runQuery(provider, {
+        query = contract.createQuery({
             func: new ContractFunction("balanceOf"),
             args: [new AddressValue(carol.address)]
         });
+        queryResponse = await provider.queryContract(query);
+
         assert.equal(1500, decodeUnsignedNumber(queryResponse.getReturnDataParts()[0]));
     });
 
@@ -300,20 +306,22 @@ describe("test on local testnet", function () {
         assert.isTrue(bundle.returnCode.isSuccess());
 
         // Query state, do some assertions
-        let queryResponse = await contract.runQuery(provider, {
+        let query = contract.createQuery({
             func: new ContractFunction("status"),
             args: [
                 BytesValue.fromUTF8("lucky")
             ]
         });
+        let queryResponse = await provider.queryContract(query);
         assert.equal(decodeUnsignedNumber(queryResponse.getReturnDataParts()[0]), 1);
 
-        queryResponse = await contract.runQuery(provider, {
+        query = contract.createQuery({
             func: new ContractFunction("status"),
             args: [
                 BytesValue.fromUTF8("missingLottery")
             ]
         });
+        queryResponse = await provider.queryContract(query);
         assert.equal(decodeUnsignedNumber(queryResponse.getReturnDataParts()[0]), 0);
     });
 });

--- a/src/smartcontracts/smartContract.ts
+++ b/src/smartcontracts/smartContract.ts
@@ -9,8 +9,6 @@ import { ArwenVirtualMachine } from "./transactionPayloadBuilders";
 import { Nonce } from "../nonce";
 import { ContractFunction } from "./function";
 import { Query } from "./query";
-import { QueryResponse } from "./queryResponse";
-import { IProvider } from "../interface";
 import { SmartContractAbi } from "./abi";
 import { guardValueIsSet } from "../utils";
 import { TypedValue } from "./typesystem";
@@ -222,20 +220,14 @@ export class SmartContract implements ISmartContract {
         return transaction;
     }
 
-    async runQuery(
-        provider: IProvider,
-        { func, args, value, caller }: QueryArguments)
-        : Promise<QueryResponse> {
-        let query = new Query({
+    createQuery({ func, args, value, caller }: QueryArguments): Query {
+        return new Query({
             address: this.address,
             func: func,
             args: args,
             value: value,
             caller: caller
         });
-
-        let response = await provider.queryContract(query);
-        return response;
     }
 
     /**


### PR DESCRIPTION
Removed `smartContract.runQuery()` in order to decouple the contract class from the network provider. `smartContract.createQuery()` + `provider.queryContract()` have to be used, instead.