### PR TITLE
Breaking change: rename "methods" to "methodsExplicit". Rename "methodsAuto" to "methods" (default choice).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - [Breaking change: unifying provider interfaces, preparing network providers for extraction - step 4](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/184)
  - [Breaking change: unifying provider interfaces, preparing network providers for extraction - step 5](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/185)
  - [Breaking change: extractions (network providers and contract wrappers)](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/186)
+ - [Breaking change: rename "methods" to "methodsExplicit". Rename "methodsAuto" to "methods" (default choice)](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/187)
 
  **Breaking changes**
  - Removed utility functions: `transaction.awaitExecuted()`, `transaction.awaitPending()`. `TransactionWatcher` should be used directly, instead.
@@ -36,6 +37,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
  - Moved network providers and contract wrappers to separate repositories:
    - https://github.com/ElrondNetwork/elrond-sdk-erdjs-network-providers
    - https://github.com/ElrondNetwork/elrond-sdk-erdjs-contract-wrappers
+ - Rename `methods` to `methodsExplicit`. Rename `methodsAuto` (only added in erdjs 10 beta) to `methods` (default choice). Therefore, by default, interactions are created without having to pass `TypedValue` objects as parameters. Automatic type inference is applied.
 
 ## [10.0.0-beta.3]
  - [Extract dapp / signing providers to separate repositories](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/170)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -345,6 +345,19 @@ export class ErrTypingSystem extends Err {
 }
 
 /**
+ * Signals a usage error related to "contract.methods" vs. "contract.methodsExplicit".
+ */
+ export class ErrTypeInferenceSystemRequiresRegularJavascriptObjects extends ErrTypingSystem {
+  public constructor(index: number) {
+    super(`
+argument at position ${index} seems to be a TypedValue. The automatic type inference system requires regular javascript objects as input.
+This error might occur when you pass a TypedValue to contract.methods.myFunction([...]). For passing TypedValues instead of regular javascript objects, and bypass the automatic type inference system, use contract.methodsExplicit.myFunction([...]) instead.
+Also see https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/187.
+`);
+  }
+}
+
+/**
  * Signals a missing field on a struct.
  */
  export class ErrMissingFieldOnStruct extends Err {

--- a/src/smartcontracts/interaction.local.net.spec.ts
+++ b/src/smartcontracts/interaction.local.net.spec.ts
@@ -146,28 +146,23 @@ describe("test smart contract interactor", function () {
         assert.isTrue(returnCode.isSuccess());
 
         let startInteraction = <Interaction>contract.methods.start([
-            BytesValue.fromUTF8("lucky"),
-            new TokenIdentifierValue("EGLD"),
-            new BigUIntValue(1),
-            OptionValue.newMissing(),
-            OptionValue.newMissing(),
-            OptionValue.newProvided(new U32Value(1)),
-            OptionValue.newMissing(),
-            OptionValue.newMissing(),
-            OptionalValue.newMissing()
+            "lucky",
+            "EGLD",
+            1,
+            null,
+            null,
+            1,
+            null,
+            null
         ])
         .withGasLimit(new GasLimit(30000000))
         .withChainID(network.ChainID);
 
-        let lotteryStatusInteraction = <Interaction>contract.methods.status([
-            BytesValue.fromUTF8("lucky")
-        ])
+        let lotteryStatusInteraction = <Interaction>contract.methods.status(["lucky"])
         .withGasLimit(new GasLimit(5000000))
         .withChainID(network.ChainID);
 
-        let getLotteryInfoInteraction = <Interaction>contract.methods.getLotteryInfo([
-            BytesValue.fromUTF8("lucky")
-        ])
+        let getLotteryInfoInteraction = <Interaction>contract.methods.getLotteryInfo(["lucky"])
         .withGasLimit(new GasLimit(5000000))
         .withChainID(network.ChainID);
 

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -176,7 +176,7 @@ describe("test smart contract interactor", function() {
         let contract = new SmartContract({ address: dummyAddress, abi: abi });
         let controller = new DefaultSmartContractController(abi, provider);
 
-        let getInteraction = <Interaction>contract.methods.get();
+        let getInteraction = <Interaction>contract.methodsExplicit.get();
         let incrementInteraction = (<Interaction>contract.methods.increment()).withGasLimit(new GasLimit(543210));
         let decrementInteraction = (<Interaction>contract.methods.decrement()).withGasLimit(new GasLimit(987654));
 
@@ -224,7 +224,7 @@ describe("test smart contract interactor", function() {
         let controller = new DefaultSmartContractController(abi, provider);
 
         let startInteraction = <Interaction>(
-            contract.methods
+            contract.methodsExplicit
                 .start([
                     BytesValue.fromUTF8("lucky"),
                     new TokenIdentifierValue("lucky-token"),
@@ -240,11 +240,11 @@ describe("test smart contract interactor", function() {
         );
 
         let statusInteraction = <Interaction>(
-            contract.methods.status([BytesValue.fromUTF8("lucky")]).withGasLimit(new GasLimit(5000000))
+            contract.methods.status(["lucky"]).withGasLimit(new GasLimit(5000000))
         );
 
         let getLotteryInfoInteraction = <Interaction>(
-            contract.methods.getLotteryInfo([BytesValue.fromUTF8("lucky")]).withGasLimit(new GasLimit(5000000))
+            contract.methods.getLotteryInfo(["lucky"]).withGasLimit(new GasLimit(5000000))
         );
 
         // start()

--- a/src/smartcontracts/interactionChecker.spec.ts
+++ b/src/smartcontracts/interactionChecker.spec.ts
@@ -8,7 +8,6 @@ import { Address } from "../address";
 import { assert } from "chai";
 import { Interaction } from "./interaction";
 import { Balance } from "../balance";
-import BigNumber from "bignumber.js";
 import { BytesValue } from "./typesystem/bytes";
 
 describe("integration tests: test checker within interactor", function () {
@@ -29,9 +28,8 @@ describe("integration tests: test checker within interactor", function () {
 
         // Bad arguments
         assert.throw(() => {
-            let interaction = (<Interaction>contract.methods.getUltimateAnswer([BytesValue.fromHex("abba")]));
-            checker.checkInteraction(interaction, endpoint);
-        }, errors.ErrContractInteraction, "bad arguments, expected: 0, got: 1");
+            contract.methods.getUltimateAnswer([BytesValue.fromHex("abba")]);
+        }, Error, "Wrong number of arguments for endpoint getUltimateAnswer: expected between 0 and 0 arguments, have 1");
     });
 
     it("should detect errors for 'lottery'", async function () {
@@ -42,17 +40,15 @@ describe("integration tests: test checker within interactor", function () {
 
         // Bad number of arguments
         assert.throw(() => {
-            let interaction = contract.methods.start([
-                BytesValue.fromUTF8("lucky"),
-                new BigUIntValue(Balance.egld(1).valueOf()),
-                OptionValue.newMissing()
+            contract.methods.start([
+                "lucky",
+                Balance.egld(1)
             ]);
-            checker.checkInteraction(interaction, endpoint);
-        }, errors.ErrContractInteraction, "bad arguments, expected: 9, got: 3");
+        }, Error, "Wrong number of arguments for endpoint start: expected between 8 and 9 arguments, have 2");
 
         // Bad types (U64 instead of U32)
         assert.throw(() => {
-            let interaction = contract.methods.start([
+            let interaction = contract.methodsExplicit.start([
                 BytesValue.fromUTF8("lucky"),
                 new TokenIdentifierValue("lucky-token"),
                 new BigUIntValue(1),

--- a/src/smartcontracts/interactionChecker.spec.ts
+++ b/src/smartcontracts/interactionChecker.spec.ts
@@ -28,7 +28,7 @@ describe("integration tests: test checker within interactor", function () {
 
         // Bad arguments
         assert.throw(() => {
-            contract.methods.getUltimateAnswer([BytesValue.fromHex("abba")]);
+            contract.methods.getUltimateAnswer(["abba"]);
         }, Error, "Wrong number of arguments for endpoint getUltimateAnswer: expected between 0 and 0 arguments, have 1");
     });
 

--- a/src/smartcontracts/nativeSerializer.ts
+++ b/src/smartcontracts/nativeSerializer.ts
@@ -5,7 +5,7 @@ import { Struct, Field, StructType, Tuple } from "./typesystem";
 import { BalanceBuilder } from "../balanceBuilder";
 import { Address } from "../address";
 import { Code } from "./code";
-import { ErrInvalidArgument } from "../errors";
+import { ErrInvalidArgument, ErrTypeInferenceSystemRequiresRegularJavascriptObjects, ErrTypingSystem } from "../errors";
 
 export namespace NativeTypes {
     export type NativeBuffer = Buffer | string | BalanceBuilder;
@@ -19,6 +19,7 @@ export namespace NativeSerializer {
      */
     export function nativeToTypedValues(args: any[], endpoint: EndpointDefinition): TypedValue[] {
         args = args || [];
+        assertNotTypedValues(args);
         args = handleVariadicArgsAndRePack(args, endpoint);
 
         let parameters = endpoint.input;
@@ -32,6 +33,16 @@ export namespace NativeSerializer {
         }
 
         return values;
+    }
+
+    function assertNotTypedValues(args: any[]) {
+        for (let i = 0; i < args.length; i++) {
+            let arg = args[i];
+
+            if (arg && arg.belongsToTypesystem) {
+                throw new ErrTypeInferenceSystemRequiresRegularJavascriptObjects(i);
+            }
+        }
     }
 
     function handleVariadicArgsAndRePack(args: any[], endpoint: EndpointDefinition) {

--- a/src/smartcontracts/smartContract.ts
+++ b/src/smartcontracts/smartContract.ts
@@ -32,16 +32,16 @@ export class SmartContract implements ISmartContract {
      * This object contains a function for each endpoint defined by the contract.
      * (a bit similar to web3js's "contract.methods").
      */
-    public readonly methods: { [key: string]: (args?: TypedValue[]) => Interaction } = {};
+    public readonly methodsExplicit: { [key: string]: (args?: TypedValue[]) => Interaction } = {};
 
     /**
      * This object contains a function for each endpoint defined by the contract.
      * (a bit similar to web3js's "contract.methods").
      * 
-     * This is an alternative to {@link methods}. 
-     * Unlike {@link methods}, automatic type inference (wrt. ABI) is applied when using {@link methodsAuto}.
+     * This is an alternative to {@link methodsExplicit}. 
+     * Unlike {@link methodsExplicit}, automatic type inference (wrt. ABI) is applied when using {@link methods}.
      */
-    public readonly methodsAuto: { [key: string]: (args?: any[]) => Interaction } = {};
+    public readonly methods: { [key: string]: (args?: any[]) => Interaction } = {};
 
     /**
      * Create a SmartContract object by providing its address on the Network.
@@ -49,7 +49,6 @@ export class SmartContract implements ISmartContract {
     constructor({ address, abi }: { address?: Address, abi?: SmartContractAbi }) {
         this.address = address || new Address();
         this.abi = abi;
-        this.methods = {};
 
         if (abi) {
             this.setupMethods();
@@ -66,13 +65,13 @@ export class SmartContract implements ISmartContract {
             // For each endpoint defined by the ABI, we attach a function to the "methods" and "methodsAuto" objects,
             // a function that receives typed values as arguments
             // and returns a prepared contract interaction.
-            this.methods[functionName] = function (args?: TypedValue[]) {
+            this.methodsExplicit[functionName] = function (args?: TypedValue[]) {
                 let func = new ContractFunction(functionName);
                 let interaction = new Interaction(contract, func, args || []);
                 return interaction;
             };
 
-            this.methodsAuto[functionName] = function (args?: any[]) {
+            this.methods[functionName] = function (args?: any[]) {
                 let func = new ContractFunction(functionName);
                 // Perform automatic type inference, wrt. the endpoint definition:
                 let typedArgs = NativeSerializer.nativeToTypedValues(args || [], definition);


### PR DESCRIPTION
According to: https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/159#discussion_r834394672

Rename `methods` to `methodsExplicit`. Rename `methodsAuto` (only added in erdjs 10 beta) to `methods` (default choice). Therefore, by default, interactions are created without having to pass `TypedValue` objects as parameters. Automatic type inference is applied.