### PR TITLE
[Regression] When loading the ABI, sort custom types by their type dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Unreleased
  - TBD
 
+## 10.2.1
+ - [When loading the ABI, sort custom types by their type dependencies](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/208)
+
 ## 10.2.0
  - [Define Transaction Factory and Gas Estimator](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/203)
  - [Fix type mapper / ABI registry (scenario: nested structs with ArrayN)](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/198)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elrondnetwork/erdjs",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elrondnetwork/erdjs",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elrondnetwork/transaction-decoder": "0.1.0",
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.12.tgz",
+      "integrity": "sha512-az/NhpIwP3K33ILr0T2bso+k2E/SLf8Yidd8mHl0n6sCQ4YdyC8qDhZA6kOPDNDBA56ZnIjngVl0U3jREA0BUA==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2092,9 +2092,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.129",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
-      "integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ==",
+      "version": "1.4.131",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.131.tgz",
+      "integrity": "sha512-oi3YPmaP87hiHn0c4ePB67tXaF+ldGhxvZnT19tW9zX6/Ej+pLN0Afja5rQ6S+TND7I9EuwQTT8JYn1k7R7rrw==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -4844,26 +4844,28 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6125,9 +6127,9 @@
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.12.tgz",
+      "integrity": "sha512-az/NhpIwP3K33ILr0T2bso+k2E/SLf8Yidd8mHl0n6sCQ4YdyC8qDhZA6kOPDNDBA56ZnIjngVl0U3jREA0BUA==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
@@ -7462,9 +7464,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.129",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
-      "integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ==",
+      "version": "1.4.131",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.131.tgz",
+      "integrity": "sha512-oi3YPmaP87hiHn0c4ePB67tXaF+ldGhxvZnT19tW9zX6/Ej+pLN0Afja5rQ6S+TND7I9EuwQTT8JYn1k7R7rrw==",
       "dev": true
     },
     "elliptic": {
@@ -9637,23 +9639,25 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/erdjs",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "Smart Contracts interaction framework",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/smartcontracts/typesystem/abiRegistry.spec.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.spec.ts
@@ -99,6 +99,10 @@ describe("test abi registry", () => {
     });
 
     it("should load ABI when custom types are out of order", async () => {
-        await loadAbiRegistry("src/testdata/custom-types-out-of-order.abi.json");
+        const registry = await loadAbiRegistry("src/testdata/custom-types-out-of-order.abi.json");
+
+        assert.deepEqual(registry.getStruct("TypeA").getNamesOfDependencies(), ["TypeB", "TypeC", "u64"]);
+        assert.deepEqual(registry.getStruct("TypeB").getNamesOfDependencies(), ["TypeC", "u64"]);
+        assert.deepEqual(registry.getStruct("TypeC").getNamesOfDependencies(), ["u64"]);
     });
 });

--- a/src/smartcontracts/typesystem/abiRegistry.spec.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.spec.ts
@@ -97,4 +97,8 @@ describe("test abi registry", () => {
         assert.isTrue(dummyType == dummyTypeFromFooTypeFromBarType);
         assert.equal(dummyType.getFieldDefinition("raw")!.type.getClassName(), ArrayVecType.ClassName);
     });
+
+    it("should load ABI when custom types are out of order", async () => {
+        await loadAbiRegistry("src/testdata/custom-types-out-of-order.abi.json");
+    });
 });

--- a/src/smartcontracts/typesystem/enum.ts
+++ b/src/smartcontracts/typesystem/enum.ts
@@ -34,6 +34,16 @@ export class EnumType extends CustomType {
         guardValueIsSet(`variant by name (${name})`, result);
         return result!;
     }
+
+    getNamesOfDependencies(): string[] {
+        const dependencies: string[] = [];
+
+        for (const variant of this.variants) {
+            dependencies.push(...variant.getNamesOfDependencies());
+        }
+
+        return [...new Set(dependencies)];
+    }
 }
 
 export class EnumVariantDefinition {
@@ -63,6 +73,10 @@ export class EnumVariantDefinition {
 
     getFieldDefinition(name: string): FieldDefinition | undefined {
         return this.fieldsDefinitions.find(item => item.name == name);
+    }
+
+    getNamesOfDependencies(): string[] {
+        return Fields.getNamesOfTypeDependencies(this.fieldsDefinitions);
     }
 }
 

--- a/src/smartcontracts/typesystem/fields.ts
+++ b/src/smartcontracts/typesystem/fields.ts
@@ -74,4 +74,15 @@ export class Fields {
 
         return true;
     }
+
+    static getNamesOfTypeDependencies(definitions: FieldDefinition[]): string[] {
+        const dependencies: string[] = [];
+
+        for (const definition of definitions) {
+            dependencies.push(definition.type.getName());
+            dependencies.push(...definition.type.getNamesOfDependencies());
+        }
+
+        return [...new Set(dependencies)];
+    }
 }

--- a/src/smartcontracts/typesystem/struct.ts
+++ b/src/smartcontracts/typesystem/struct.ts
@@ -27,6 +27,10 @@ export class StructType extends CustomType {
     getFieldDefinition(name: string): FieldDefinition | undefined {
         return this.fieldsDefinitions.find(item => item.name == name);
     }
+
+    getNamesOfDependencies(): string[] {
+        return Fields.getNamesOfTypeDependencies(this.fieldsDefinitions);
+    }
 }
 
 export class Struct extends TypedValue {

--- a/src/smartcontracts/typesystem/types.spec.ts
+++ b/src/smartcontracts/typesystem/types.spec.ts
@@ -66,4 +66,10 @@ describe("test types", () => {
         assert.deepEqual(new BytesType().getClassHierarchy(), ["Type", "PrimitiveType", "BytesType"]);
         assert.deepEqual(new BytesValue(Buffer.from("foobar")).getClassHierarchy(), ["TypedValue", "PrimitiveValue", "BytesValue"]);
     });
+
+    it("should report type dependencies", () => {
+        assert.deepEqual(parser.parse("MultiResultVec<u32>").getNamesOfDependencies(), ["u32"]);
+        assert.deepEqual(parser.parse("tuple2<Address,BigUint>").getNamesOfDependencies(), ["Address", "BigUint"]);
+        assert.deepEqual(parser.parse("Option<FooBar>").getNamesOfDependencies(), ["FooBar"]);
+    });
 });

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -133,6 +133,17 @@ export class Type {
         return fullyQualifiedNames;
     }
 
+    getNamesOfDependencies(): string[] {
+        const dependencies: string[] = [];
+
+        for (const type of this.typeParameters) {
+            dependencies.push(type.getName());
+            dependencies.push(...type.getNamesOfDependencies());
+        }
+
+        return [...new Set(dependencies)];
+    }
+
     /**
      * Converts the account to a pretty, plain JavaScript object.
      */

--- a/src/testdata/custom-types-out-of-order.abi.json
+++ b/src/testdata/custom-types-out-of-order.abi.json
@@ -34,6 +34,33 @@
                     "discriminant": 1
                 }
             ]
+        },
+        "TypeA": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "b",
+                    "type": "TypeB"
+                }
+            ]
+        },
+        "TypeB": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "c",
+                    "type": "TypeC"
+                }
+            ]
+        },
+        "TypeC": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "foobar",
+                    "type": "u64"
+                }
+            ]
         }
     }
 }

--- a/src/testdata/custom-types-out-of-order.abi.json
+++ b/src/testdata/custom-types-out-of-order.abi.json
@@ -1,0 +1,39 @@
+{
+    "name": "Sample",
+    "types": {
+        "EsdtTokenPayment": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "token_type",
+                    "type": "EsdtTokenType"
+                },
+                {
+                    "name": "token_identifier",
+                    "type": "TokenIdentifier"
+                },
+                {
+                    "name": "token_nonce",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount",
+                    "type": "BigUint"
+                }
+            ]
+        },
+        "EsdtTokenType": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "Fungible",
+                    "discriminant": 0
+                },
+                {
+                    "name": "NonFungible",
+                    "discriminant": 1
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
 - Define `Type.getNamesOfDependencies()`
 - When loading the ABI, sort custom types by their type dependencies (if B depends on A, then A precedes B).