### PR TITLE
Decoupling, minor refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Unreleased
  - TBD
 
+## 10.2.2
+ - [Decoupling, minor refactoring](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/209)
+
 ## 10.2.1
  - [When loading the ABI, sort custom types by their type dependencies](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/208)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elrondnetwork/erdjs",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elrondnetwork/erdjs",
-      "version": "10.2.1",
+      "version": "10.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elrondnetwork/transaction-decoder": "0.1.0",
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001335",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-      "integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
+      "version": "1.0.30001336",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
+      "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
       "dev": true,
       "funding": [
         {
@@ -2092,9 +2092,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.131",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.131.tgz",
-      "integrity": "sha512-oi3YPmaP87hiHn0c4ePB67tXaF+ldGhxvZnT19tW9zX6/Ej+pLN0Afja5rQ6S+TND7I9EuwQTT8JYn1k7R7rrw==",
+      "version": "1.4.134",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.134.tgz",
+      "integrity": "sha512-OdD7M2no4Mi8PopfvoOuNcwYDJ2mNFxaBfurA6okG3fLBaMcFah9S+si84FhX+FIWLKkdaiHfl4A+5ep/gOVrg==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -2558,9 +2558,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
       "dev": true,
       "funding": [
         {
@@ -7006,9 +7006,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001335",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-      "integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
+      "version": "1.0.30001336",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
+      "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
       "dev": true
     },
     "chai": {
@@ -7464,9 +7464,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.131",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.131.tgz",
-      "integrity": "sha512-oi3YPmaP87hiHn0c4ePB67tXaF+ldGhxvZnT19tW9zX6/Ej+pLN0Afja5rQ6S+TND7I9EuwQTT8JYn1k7R7rrw==",
+      "version": "1.4.134",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.134.tgz",
+      "integrity": "sha512-OdD7M2no4Mi8PopfvoOuNcwYDJ2mNFxaBfurA6okG3fLBaMcFah9S+si84FhX+FIWLKkdaiHfl4A+5ep/gOVrg==",
       "dev": true
     },
     "elliptic": {
@@ -7868,9 +7868,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
       "dev": true
     },
     "foreach": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/erdjs",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "description": "Smart Contracts interaction framework",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -27,6 +27,6 @@ export interface ITransactionPayload {
 export interface ITokenPayment {
     readonly tokenIdentifier: string;
     readonly nonce: number;
-    readonly amountAsBigInteger: BigNumber;
-    valueOf(): BigNumber;
+    readonly amountAsBigInteger: BigNumber.Value;
+    valueOf(): BigNumber.Value;
 }

--- a/src/smartcontracts/abi.ts
+++ b/src/smartcontracts/abi.ts
@@ -1,24 +1,18 @@
-import { ErrInvariantFailed } from "../errors";
 import { guardValueIsSetWithMessage } from "../utils";
 import { ContractFunction } from "./function";
 import { AbiRegistry, EndpointDefinition } from "./typesystem";
 import { ContractInterface } from "./typesystem/contractInterface";
 
 export class SmartContractAbi {
-    private readonly interfaces: ContractInterface[] = [];
+    private readonly interface: ContractInterface;
 
-    constructor(registry: AbiRegistry, implementsInterfaces: string[]) {
-        this.interfaces.push(...registry.getInterfaces(implementsInterfaces));
+    // TODO (breaking, next major version): remove second parameter (not used anymore).
+    constructor(registry: AbiRegistry, _implementsInterfaces?: string[]) {
+        this.interface = registry.interfaces[0];
     }
     
     getAllEndpoints(): EndpointDefinition[] {
-        let endpoints = [];
-
-        for (const iface of this.interfaces) {
-            endpoints.push(...iface.endpoints);
-        }
-
-        return endpoints;
+        return this.interface.endpoints;
     }
 
     getEndpoint(name: string | ContractFunction): EndpointDefinition {
@@ -31,20 +25,6 @@ export class SmartContractAbi {
     }
 
     getConstructorDefinition(): EndpointDefinition | null {
-        let constructors = [];
-        for (const iface of this.interfaces) {
-            let constructor_definition = iface.getConstructorDefinition();
-            if (constructor_definition !== null) {
-                constructors.push(constructor_definition);
-            }
-        }
-        switch (constructors.length) {
-            case 0:
-                return null;
-            case 1:
-                return constructors[0];
-            default:
-                throw new ErrInvariantFailed(`Found more than 1 constructor (found ${constructors.length})`);
-        }
+        return this.interface.getConstructorDefinition();
     }
 }

--- a/src/smartcontracts/function.ts
+++ b/src/smartcontracts/function.ts
@@ -40,6 +40,7 @@ export class ContractFunction {
         return this.name;
     }
 
+    // TODO (breaking, next major version): remove function, not used.
     equals(other: ContractFunction | null): boolean {
         if (!other) {
             return false;

--- a/src/smartcontracts/interface.ts
+++ b/src/smartcontracts/interface.ts
@@ -1,8 +1,5 @@
 import { IAddress, IChainID, IGasLimit, IGasPrice, ITransactionValue } from "../interface";
 import { Transaction } from "../transaction";
-import { Code } from "./code";
-import { CodeMetadata } from "./codeMetadata";
-import { ContractFunction } from "./function";
 import { ReturnCode } from "./returnCode";
 import { TypedValue } from "./typesystem";
 
@@ -32,8 +29,8 @@ export interface ISmartContract {
 }
 
 export interface DeployArguments {
-    code: Code;
-    codeMetadata?: CodeMetadata;
+    code: ICode;
+    codeMetadata?: ICodeMetadata;
     initArguments?: TypedValue[];
     value?: ITransactionValue;
     gasLimit: IGasLimit;
@@ -42,8 +39,8 @@ export interface DeployArguments {
 }
 
 export interface UpgradeArguments {
-    code: Code;
-    codeMetadata?: CodeMetadata;
+    code: ICode;
+    codeMetadata?: ICodeMetadata;
     initArguments?: TypedValue[];
     value?: ITransactionValue;
     gasLimit: IGasLimit;
@@ -52,7 +49,7 @@ export interface UpgradeArguments {
 }
 
 export interface CallArguments {
-    func: ContractFunction;
+    func: IContractFunction;
     args?: TypedValue[];
     value?: ITransactionValue;
     gasLimit: IGasLimit;
@@ -62,7 +59,7 @@ export interface CallArguments {
 }
 
 export interface QueryArguments {
-    func: ContractFunction;
+    func: IContractFunction;
     args?: TypedValue[];
     value?: ITransactionValue;
     caller?: IAddress
@@ -82,4 +79,17 @@ export interface UntypedOutcomeBundle {
     returnCode: ReturnCode;
     returnMessage: string;
     values: Buffer[];
+}
+
+interface ICode {
+    toString(): string;
+}
+
+interface ICodeMetadata {
+    toString(): string;
+}
+
+export interface IContractFunction {
+    name: string;
+    toString(): string;
 }

--- a/src/smartcontracts/interface.ts
+++ b/src/smartcontracts/interface.ts
@@ -81,11 +81,11 @@ export interface UntypedOutcomeBundle {
     values: Buffer[];
 }
 
-interface ICode {
+export interface ICode {
     toString(): string;
 }
 
-interface ICodeMetadata {
+export interface ICodeMetadata {
     toString(): string;
 }
 

--- a/src/smartcontracts/query.ts
+++ b/src/smartcontracts/query.ts
@@ -1,20 +1,20 @@
-import { ContractFunction } from "./function";
 import { Address } from "../address";
 import { TypedValue } from "./typesystem";
 import { ArgSerializer } from "./argSerializer";
 import { IAddress, ITransactionValue } from "../interface";
+import { IContractFunction } from "./interface";
 
 export class Query {
     caller: IAddress;
     address: IAddress;
-    func: ContractFunction;
+    func: IContractFunction;
     args: TypedValue[];
     value: ITransactionValue;
 
     constructor(obj: {
         caller?: IAddress,
         address: IAddress,
-        func: ContractFunction,
+        func: IContractFunction,
         args?: TypedValue[],
         value?: ITransactionValue
     }) {

--- a/src/smartcontracts/transactionPayloadBuilders.ts
+++ b/src/smartcontracts/transactionPayloadBuilders.ts
@@ -1,26 +1,35 @@
 
 import { TransactionPayload } from "../transactionPayload";
 import { guardValueIsSet } from "../utils";
-import { Code } from "./code";
-import { CodeMetadata } from "./codeMetadata";
-import { ContractFunction } from "./function";
 import { ArgSerializer } from "./argSerializer";
 import { TypedValue } from "./typesystem";
 
 export const ArwenVirtualMachine = "0500";
 
+interface ICode {
+    toString(): string;
+}
+
+interface ICodeMetadata {
+    toString(): string;
+}
+
+interface IContractFunction {
+    name: string;
+}
+
 /**
  * A builder for {@link TransactionPayload} objects, to be used for Smart Contract deployment transactions.
  */
 export class ContractDeployPayloadBuilder {
-    private code: Code | null = null;
-    private codeMetadata: CodeMetadata = new CodeMetadata();
+    private code: ICode | null = null;
+    private codeMetadata: ICodeMetadata = "";
     private arguments: TypedValue[] = [];
 
     /**
      * Sets the code of the Smart Contract.
      */
-    setCode(code: Code): ContractDeployPayloadBuilder {
+    setCode(code: ICode): ContractDeployPayloadBuilder {
         this.code = code;
         return this;
     }
@@ -28,7 +37,7 @@ export class ContractDeployPayloadBuilder {
     /**
      * Sets the code metadata of the Smart Contract.
      */
-    setCodeMetadata(codeMetadata: CodeMetadata): ContractDeployPayloadBuilder {
+    setCodeMetadata(codeMetadata: ICodeMetadata): ContractDeployPayloadBuilder {
         this.codeMetadata = codeMetadata;
         return this;
     }
@@ -68,14 +77,14 @@ export class ContractDeployPayloadBuilder {
  * A builder for {@link TransactionPayload} objects, to be used for Smart Contract upgrade transactions.
  */
 export class ContractUpgradePayloadBuilder {
-    private code: Code | null = null;
-    private codeMetadata: CodeMetadata = new CodeMetadata();
+    private code: ICode | null = null;
+    private codeMetadata: ICodeMetadata = "";
     private arguments: TypedValue[] = [];
 
     /**
      * Sets the code of the Smart Contract.
      */
-    setCode(code: Code): ContractUpgradePayloadBuilder {
+    setCode(code: ICode): ContractUpgradePayloadBuilder {
         this.code = code;
         return this;
     }
@@ -83,7 +92,7 @@ export class ContractUpgradePayloadBuilder {
     /**
      * Sets the code metadata of the Smart Contract.
      */
-    setCodeMetadata(codeMetadata: CodeMetadata): ContractUpgradePayloadBuilder {
+    setCodeMetadata(codeMetadata: ICodeMetadata): ContractUpgradePayloadBuilder {
         this.codeMetadata = codeMetadata;
         return this;
     }
@@ -123,13 +132,13 @@ export class ContractUpgradePayloadBuilder {
  * A builder for {@link TransactionPayload} objects, to be used for Smart Contract execution transactions.
  */
 export class ContractCallPayloadBuilder {
-    private contractFunction: ContractFunction | null = null;
+    private contractFunction: IContractFunction | null = null;
     private arguments: TypedValue[] = [];
 
     /**
      * Sets the function to be called (executed).
      */
-    setFunction(contractFunction: ContractFunction): ContractCallPayloadBuilder {
+    setFunction(contractFunction: IContractFunction): ContractCallPayloadBuilder {
         this.contractFunction = contractFunction;
         return this;
     }

--- a/src/smartcontracts/transactionPayloadBuilders.ts
+++ b/src/smartcontracts/transactionPayloadBuilders.ts
@@ -2,21 +2,10 @@
 import { TransactionPayload } from "../transactionPayload";
 import { guardValueIsSet } from "../utils";
 import { ArgSerializer } from "./argSerializer";
+import { ICode, ICodeMetadata, IContractFunction } from "./interface";
 import { TypedValue } from "./typesystem";
 
 export const ArwenVirtualMachine = "0500";
-
-interface ICode {
-    toString(): string;
-}
-
-interface ICodeMetadata {
-    toString(): string;
-}
-
-interface IContractFunction {
-    name: string;
-}
 
 /**
  * A builder for {@link TransactionPayload} objects, to be used for Smart Contract deployment transactions.

--- a/src/tokenPayment.ts
+++ b/src/tokenPayment.ts
@@ -11,8 +11,9 @@ export class TokenPayment {
     readonly tokenIdentifier: string;
     readonly nonce: number;
     readonly amountAsBigInteger: BigNumber;
-    private readonly numDecimals: number;
+    readonly numDecimals: number;
 
+    // TODO (breaking, next major version): constructor({ ... })
     constructor(tokenIdentifier: string, nonce: number, amountAsBigInteger: BigNumber.Value, numDecimals: number) {
         let amount = new BigNumber(amountAsBigInteger);
         if (!amount.isInteger() || amount.isNegative()) {
@@ -72,6 +73,7 @@ export class TokenPayment {
         return `${this.toRationalNumber()} ${this.tokenIdentifier}`;
     }
 
+    // TODO (breaking, next major version): rename to "toAmount()", make it private.
     toRationalNumber() {
         return this.amountAsBigInteger.shiftedBy(-this.numDecimals).toFixed(this.numDecimals);
     }


### PR DESCRIPTION
 - `TokenPayment.numDecimals` is now a public field.
 - `ITokenPayment` now has `BigNumber.Value` as output dependency, instead of `BigNumber`. Theoretically, this isn't a breaking change (interface is used as an input dependency): an [old `ITokenPayment`] is assignable to a variable of the type [new `ITokenPayment`].
 - Some decoupling from `Code`, `CodeMetadata`, `ContractFunction`.
 - Simplification: ignore second parameter of new `SmartContractAbi().`
 - Added some TODOs (for future breaking changes). 

