### PR TITLE
Minor improvements / fixes

### DIFF
--- a/.github/workflows/erdjs-publish-alpha-beta.yml
+++ b/.github/workflows/erdjs-publish-alpha-beta.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       
       - name: Create release

--- a/.github/workflows/erdjs-publish.yml
+++ b/.github/workflows/erdjs-publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       
       - name: Create release

--- a/.github/workflows/erdjs.yml
+++ b/.github/workflows/erdjs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Unreleased
  - TBD
 
+## 10.2.3
+ - [Minor improvements and fixes](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/210)
+
 ## 10.2.2
  - [Decoupling, minor refactoring](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/209)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elrondnetwork/erdjs",
-  "version": "10.2.2",
+  "version": "10.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elrondnetwork/erdjs",
-      "version": "10.2.2",
+      "version": "10.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@elrondnetwork/transaction-decoder": "0.1.0",
@@ -533,33 +533,33 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
-      "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
-      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.12.tgz",
-      "integrity": "sha512-az/NhpIwP3K33ILr0T2bso+k2E/SLf8Yidd8mHl0n6sCQ4YdyC8qDhZA6kOPDNDBA56ZnIjngVl0U3jREA0BUA==",
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.10.tgz",
+      "integrity": "sha512-Q0YbBd6OTsXm8Y21+YUSDXupHnodNC2M4O18jtd3iwJ3+vMZNdKGols0a9G6JOK0dcJ3IdUUHoh908ZI6qhk8Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001336",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
-      "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
+      "version": "1.0.30001338",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
       "dev": true,
       "funding": [
         {
@@ -2092,9 +2092,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.134",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.134.tgz",
-      "integrity": "sha512-OdD7M2no4Mi8PopfvoOuNcwYDJ2mNFxaBfurA6okG3fLBaMcFah9S+si84FhX+FIWLKkdaiHfl4A+5ep/gOVrg==",
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -2134,17 +2134,19 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+      "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -2156,9 +2158,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.1",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2627,6 +2630,24 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -6115,27 +6136,27 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
-      "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
       "dev": true
     },
     "@jridgewell/set-array": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
-      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.12.tgz",
-      "integrity": "sha512-az/NhpIwP3K33ILr0T2bso+k2E/SLf8Yidd8mHl0n6sCQ4YdyC8qDhZA6kOPDNDBA56ZnIjngVl0U3jREA0BUA==",
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.10.tgz",
+      "integrity": "sha512-Q0YbBd6OTsXm8Y21+YUSDXupHnodNC2M4O18jtd3iwJ3+vMZNdKGols0a9G6JOK0dcJ3IdUUHoh908ZI6qhk8Q==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -7006,9 +7027,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001336",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
-      "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
+      "version": "1.0.30001338",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
       "dev": true
     },
     "chai": {
@@ -7464,9 +7485,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.134",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.134.tgz",
-      "integrity": "sha512-OdD7M2no4Mi8PopfvoOuNcwYDJ2mNFxaBfurA6okG3fLBaMcFah9S+si84FhX+FIWLKkdaiHfl4A+5ep/gOVrg==",
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
     },
     "elliptic": {
@@ -7508,17 +7529,19 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+      "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -7530,9 +7553,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.1",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       }
     },
     "es-to-primitive": {
@@ -7916,6 +7940,18 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
     },
     "functions-have-names": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/erdjs",
-  "version": "10.2.2",
+  "version": "10.2.3",
   "description": "Smart Contracts interaction framework",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -8,6 +8,20 @@ export interface ITransactionFetcher {
     getTransaction(txHash: string): Promise<ITransactionOnNetwork>;
 }
 
+export interface IPlainTransactionObject {
+    nonce: number;
+    value: string;
+    receiver: string;
+    sender: string;
+    gasPrice: number;
+    gasLimit: number;
+    data?: string;
+    chainID: string;
+    version: number;
+    options?: number;
+    signature?: string;
+}
+
 export interface ISignature { hex(): string; }
 export interface IAddress { bech32(): string; }
 export interface ITransactionValue { toString(): string; }

--- a/src/smartcontracts/code.ts
+++ b/src/smartcontracts/code.ts
@@ -21,4 +21,8 @@ export class Code {
     toString(): string {
         return this.hex;
     }
+
+    valueOf(): Buffer {
+        return Buffer.from(this.hex, "hex");
+    }
 }

--- a/src/smartcontracts/interaction.ts
+++ b/src/smartcontracts/interaction.ts
@@ -35,6 +35,7 @@ export class Interaction {
     private gasPrice: IGasPrice | undefined = undefined;
     private chainID: IChainID = "";
     private querent: IAddress = new Address();
+    private explicitReceiver?: IAddress;
 
     private isWithSingleESDTTransfer: boolean = false;
     private isWithSingleESDTNFTTransfer: boolean = false;
@@ -81,8 +82,12 @@ export class Interaction {
         return this.gasLimit;
     }
 
+    getExplicitReceiver(): IAddress | undefined {
+        return this.explicitReceiver;
+    }
+
     buildTransaction(): Transaction {
-        let receiver = this.contract.getAddress();
+        let receiver = this.explicitReceiver || this.contract.getAddress();
         let func: ContractFunction = this.function;
         let args = this.args;
 
@@ -182,6 +187,11 @@ export class Interaction {
      */
     withQuerent(querent: IAddress): Interaction {
         this.querent = querent;
+        return this;
+    }
+
+    withExplicitReceiver(receiver: IAddress): Interaction {
+        this.explicitReceiver = receiver;
         return this;
     }
 

--- a/src/smartcontracts/nativeSerializer.spec.ts
+++ b/src/smartcontracts/nativeSerializer.spec.ts
@@ -7,37 +7,42 @@ import { ErrTypeInferenceSystemRequiresRegularJavascriptObjects } from "../error
 
 describe("test native serializer", () => {
     it("should perform type inference", async () => {
-        let endpointModifiers = new EndpointModifiers("", []);
-        let inputParameters = [
-            new EndpointParameterDefinition("a", "a", new BigUIntType()),
-            new EndpointParameterDefinition("b", "b", new ListType(new AddressType())),
-            new EndpointParameterDefinition("c", "c", new BytesType()),
-            new EndpointParameterDefinition("d", "d", new OptionType(new U32Type())),
-            new EndpointParameterDefinition("e", "e", new OptionType(new U32Type())),
-            new EndpointParameterDefinition("f", "f", new OptionalType(new BytesType()))
+        const endpointModifiers = new EndpointModifiers("", []);
+        const inputParameters = [
+            new EndpointParameterDefinition("", "", new BigUIntType()),
+            new EndpointParameterDefinition("", "", new ListType(new AddressType())),
+            new EndpointParameterDefinition("", "", new BytesType()),
+            new EndpointParameterDefinition("", "", new BytesType()),
+            new EndpointParameterDefinition("", "", new OptionType(new U32Type())),
+            new EndpointParameterDefinition("", "", new OptionType(new U32Type())),
+            new EndpointParameterDefinition("", "", new OptionalType(new BytesType()))
         ];
-        let endpoint = new EndpointDefinition("foo", inputParameters, [], endpointModifiers);
+        const endpoint = new EndpointDefinition("foo", inputParameters, [], endpointModifiers);
 
-        let a = 42;
-        let b = [new Address("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"), new Address("erd1r69gk66fmedhhcg24g2c5kn2f2a5k4kvpr6jfw67dn2lyydd8cfswy6ede")];
-        let c = Buffer.from("abba", "hex");
-        let d = null;
-        let e = 7;
+        const p0 = 42;
+        const p1 = [new Address("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"), new Address("erd1r69gk66fmedhhcg24g2c5kn2f2a5k4kvpr6jfw67dn2lyydd8cfswy6ede")];
+        const p2 = Buffer.from("abba", "hex");
+        const p3 = Number(0xabba);
+        const p4 = null;
+        const p5 = 7;
+
         // Let's not provide "f"
-        let typedValues = NativeSerializer.nativeToTypedValues([a, b, c, d, e], endpoint);
+        const typedValues = NativeSerializer.nativeToTypedValues([p0, p1, p2, p3, p4, p5], endpoint);
 
         assert.deepEqual(typedValues[0].getType(), new BigUIntType());
-        assert.deepEqual(typedValues[0].valueOf().toNumber(), a);
+        assert.deepEqual(typedValues[0].valueOf().toNumber(), p0);
         assert.deepEqual(typedValues[1].getType(), new ListType(new AddressType()));
-        assert.deepEqual(typedValues[1].valueOf(), b);
+        assert.deepEqual(typedValues[1].valueOf(), p1);
         assert.deepEqual(typedValues[2].getType(), new BytesType());
-        assert.deepEqual(typedValues[2].valueOf(), c);
-        assert.deepEqual(typedValues[3].getType(), new OptionType(new NullType()));
-        assert.deepEqual(typedValues[3].valueOf(), null);
-        assert.deepEqual(typedValues[4].getType(), new OptionType(new U32Type()));
-        assert.deepEqual(typedValues[4].valueOf().toNumber(), e);
-        assert.deepEqual(typedValues[5].getType(), new OptionalType(new BytesType()));
-        assert.deepEqual(typedValues[5].valueOf(), null);
+        assert.deepEqual(typedValues[2].valueOf(), p2);
+        assert.deepEqual(typedValues[3].getType(), new BytesType());
+        assert.deepEqual(typedValues[3].valueOf(), Buffer.from("abba", "hex"));
+        assert.deepEqual(typedValues[4].getType(), new OptionType(new NullType()));
+        assert.deepEqual(typedValues[4].valueOf(), null);
+        assert.deepEqual(typedValues[5].getType(), new OptionType(new U32Type()));
+        assert.deepEqual(typedValues[5].valueOf().toNumber(), p5);
+        assert.deepEqual(typedValues[6].getType(), new OptionalType(new BytesType()));
+        assert.deepEqual(typedValues[6].valueOf(), null);
     });
 
     it("should not accept already typed values", async () => {

--- a/src/smartcontracts/typesystem/abiRegistry.spec.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.spec.ts
@@ -101,6 +101,8 @@ describe("test abi registry", () => {
     it("should load ABI when custom types are out of order", async () => {
         const registry = await loadAbiRegistry("src/testdata/custom-types-out-of-order.abi.json");
 
+        assert.deepEqual(registry.getStruct("EsdtTokenPayment").getNamesOfDependencies(), ["EsdtTokenType", "TokenIdentifier", "u64", "BigUint"]);
+        assert.deepEqual(registry.getEnum("EsdtTokenType").getNamesOfDependencies(), []);
         assert.deepEqual(registry.getStruct("TypeA").getNamesOfDependencies(), ["TypeB", "TypeC", "u64"]);
         assert.deepEqual(registry.getStruct("TypeB").getNamesOfDependencies(), ["TypeC", "u64"]);
         assert.deepEqual(registry.getStruct("TypeC").getNamesOfDependencies(), ["u64"]);

--- a/src/smartcontracts/typesystem/abiRegistry.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.ts
@@ -49,15 +49,16 @@ export class AbiRegistry {
     }
 
     private sortCustomTypesByDependencies() {
+        // TODO: Improve consistency of the sorting function (and make sure the sorting is stable): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
         this.customTypes.sort((a: CustomType, b: CustomType) => {
-            const bDependsonA = b.getNamesOfDependencies().indexOf(a.getName()) > -1;
-            if (bDependsonA) {
+            const bDependsOnA = b.getNamesOfDependencies().indexOf(a.getName()) > -1;
+            if (bDependsOnA) {
                 // Sort "a" before "b".
                 return -1;
             }
 
-            // Keep original order.
-            return 0;
+            // Sort "b" before "a".
+            return 1;
         });
     }
 

--- a/src/transaction.spec.ts
+++ b/src/transaction.spec.ts
@@ -172,4 +172,21 @@ describe("test transaction construction", async () => {
         let fee = transaction.computeFee(networkConfig);
         assert.equal(fee.toString(), "6005000");
     });
+
+    it("should convert transaction to plain object and back", () => {
+        const sender = wallets.alice.address;
+        const transaction = new Transaction({
+            nonce: 90,
+            value: TokenPayment.egldFromAmount(1).valueOf(),
+            receiver: wallets.bob.address,
+            gasPrice: minGasPrice,
+            gasLimit: 80000,
+            data: new TransactionPayload("hello"),
+            chainID: "local-testnet"
+        });
+
+        const plainObject = transaction.toPlainObject(sender);
+        const restoredTransaction = Transaction.fromPlainObject(plainObject);
+        assert.deepEqual(restoredTransaction, transaction);
+    });
 });

--- a/src/transaction.spec.ts
+++ b/src/transaction.spec.ts
@@ -1,4 +1,5 @@
 import { assert } from "chai";
+import BigNumber from "bignumber.js";
 import { Transaction } from "./transaction";
 import { TransactionOptions, TransactionVersion } from "./networkParams";
 import { TransactionPayload } from "./transactionPayload";
@@ -177,7 +178,7 @@ describe("test transaction construction", async () => {
         const sender = wallets.alice.address;
         const transaction = new Transaction({
             nonce: 90,
-            value: TokenPayment.egldFromAmount(1).valueOf(),
+            value: new BigNumber("1000000000000000000"),
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: 80000,

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, ISignature, ITransactionPayload, ITransactionValue } from "./interface";
+import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, IPlainTransactionObject, ISignature, ITransactionPayload, ITransactionValue } from "./interface";
 import { Address } from "./address";
 import {
   TransactionOptions,
@@ -218,7 +218,7 @@ export class Transaction {
    *
    * @param sender The address of the sender (will be provided when called within the signing procedure)
    */
-  toPlainObject(sender?: IAddress): any {
+  toPlainObject(sender?: IAddress): IPlainTransactionObject {
     return {
       nonce: this.nonce.valueOf(),
       value: this.value.toString(),
@@ -239,14 +239,14 @@ export class Transaction {
    *
    * @param plainObjectTransaction Raw data of a transaction, usually obtained by calling toPlainObject()
    */
-  static fromPlainObject(plainObjectTransaction: any): Transaction {
+  static fromPlainObject(plainObjectTransaction: IPlainTransactionObject): Transaction {
     const tx = new Transaction({
       nonce: Number(plainObjectTransaction.nonce),
       value: new BigNumber(plainObjectTransaction.value),
       receiver: Address.fromString(plainObjectTransaction.receiver),
       gasPrice: Number(plainObjectTransaction.gasPrice),
       gasLimit: Number(plainObjectTransaction.gasLimit),
-      data: new TransactionPayload(atob(plainObjectTransaction.data)),
+      data: new TransactionPayload(atob(plainObjectTransaction.data || "")),
       chainID: String(plainObjectTransaction.chainID),
       version: new TransactionVersion(plainObjectTransaction.version),
     });


### PR DESCRIPTION
 - add interface `IPlainTransactionObject`
 - define `Interaction.withExplicitReceiver`
 - automatic type inference for `number` -> `bytes value`.
 - (partially) fix sorting of custom types (make the sorting function a bit more consistent) - browser tests were failing.