### PR TITLE
fix: Update type of abiRegistry types

### DIFF
--- a/src/smartcontracts/typesystem/abiRegistry.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.ts
@@ -11,13 +11,13 @@ export class AbiRegistry {
     readonly interfaces: ContractInterface[] = [];
     readonly customTypes: CustomType[] = [];
 
-    static create(json: { name: string; endpoints: any[]; types: any[] }): AbiRegistry {
+    static create(json: { name: string; endpoints: any[]; types: Record<string, any> }): AbiRegistry {
         let registry = new AbiRegistry().extend(json);
         let remappedRegistry = registry.remapToKnownTypes();
         return remappedRegistry;
     }
 
-    private extend(json: { name: string; endpoints: any[]; types: any[] }): AbiRegistry {
+    private extend(json: { name: string; endpoints: any[]; types: Record<string, any> }): AbiRegistry {
         json.types = json.types || {};
 
         // The "endpoints" collection is interpreted by "ContractInterface".


### PR DESCRIPTION
The type of the type parameters is not correct, it must be an object and not an array.
this fix is ​​not perfect, it would be better to define a more precise type, but that would already unlock the use.
