### PR TITLE
Removed Address.Zero() from transaction construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## Unreleased
- - TBD
+## 11.0.0
 
 ## 10.2.7
  - [Update reference to keccak](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/222)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## 11.0.0
+ - [Breaking change: Sender is now mandatory when constructing a transaction](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/TBD)
 
 ## 10.2.7
  - [Update reference to keccak](https://github.com/ElrondNetwork/elrond-sdk-erdjs/pull/222)

--- a/src/proto/serializer.spec.ts
+++ b/src/proto/serializer.spec.ts
@@ -20,6 +20,7 @@ describe("serialize transactions", () => {
         let transaction = new Transaction({
             nonce: 89,
             value: 0,
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasLimit: 50000,
             chainID: "local-testnet"
@@ -35,6 +36,7 @@ describe("serialize transactions", () => {
         let transaction = new Transaction({
             nonce: 90,
             value: 0,
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasLimit: 80000,
             data: new TransactionPayload("hello"),
@@ -51,6 +53,7 @@ describe("serialize transactions", () => {
         let transaction = new Transaction({
             nonce: 91,
             value: TokenPayment.egldFromAmount(10),
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasLimit: 100000,
             data: new TransactionPayload("for the book"),
@@ -67,13 +70,14 @@ describe("serialize transactions", () => {
         let transaction = new Transaction({
             nonce: 92,
             value: new BigNumber("123456789000000000000000000000"),
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasLimit: 100000,
             data: new TransactionPayload("for the spaceship"),
             chainID: "local-testnet"
         });
 
-        transaction.applySignature(new Signature("39938d15812708475dfc8125b5d41dbcea0b2e3e7aabbbfceb6ce4f070de3033676a218b73facd88b1432d7d4accab89c6130b3abe5cc7bbbb5146e61d355b03"), wallets.alice.address)
+        transaction.applySignature(new Signature("39938d15812708475dfc8125b5d41dbcea0b2e3e7aabbbfceb6ce4f070de3033676a218b73facd88b1432d7d4accab89c6130b3abe5cc7bbbb5146e61d355b03"), wallets.alice.address);
 
         let buffer = serializer.serializeTransaction(transaction);
         assert.equal(buffer.toString("hex"), "085c120e00018ee90ff6181f3761632000001a208049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f82a200139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1388094ebdc0340a08d064a11666f722074686520737061636573686970520d6c6f63616c2d746573746e65745801624039938d15812708475dfc8125b5d41dbcea0b2e3e7aabbbfceb6ce4f070de3033676a218b73facd88b1432d7d4accab89c6130b3abe5cc7bbbb5146e61d355b03");
@@ -83,6 +87,7 @@ describe("serialize transactions", () => {
         let transaction = new Transaction({
             nonce: 0,
             value: new BigNumber("0"),
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasLimit: 80000,
             data: new TransactionPayload("hello"),

--- a/src/relayedTransactionV2Builder.spec.ts
+++ b/src/relayedTransactionV2Builder.spec.ts
@@ -30,6 +30,7 @@ describe("test relayed v2 transaction builder", function () {
 
         const innerTx = new Transaction({
             nonce: 15,
+            sender: alice.address,
             receiver: Address.fromBech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"),
             gasLimit: 10,
             chainID: networkConfig.ChainID,
@@ -53,6 +54,7 @@ describe("test relayed v2 transaction builder", function () {
 
         const innerTx = new Transaction({
             nonce: 15,
+            sender: alice.address,
             receiver: Address.fromBech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"),
             gasLimit: 0,
             chainID: networkConfig.ChainID,

--- a/src/relayedTransactionV2Builder.ts
+++ b/src/relayedTransactionV2Builder.ts
@@ -70,6 +70,7 @@ export class RelayedTransactionV2Builder {
             .build();
 
         return new Transaction({
+            sender: this.innerTransaction.getSender(),
             receiver: this.innerTransaction.getSender(),
             value: 0,
             gasLimit:

--- a/src/smartcontracts/smartContract.ts
+++ b/src/smartcontracts/smartContract.ts
@@ -120,6 +120,7 @@ export class SmartContract implements ISmartContract {
 
         let transaction = new Transaction({
             receiver: Address.Zero(),
+            sender: Address.Zero(),
             value: value,
             gasLimit: gasLimit,
             gasPrice: gasPrice,
@@ -147,6 +148,7 @@ export class SmartContract implements ISmartContract {
             .build();
 
         let transaction = new Transaction({
+            sender: Address.Zero(),
             receiver: this.getAddress(),
             value: value,
             gasLimit: gasLimit,
@@ -173,6 +175,7 @@ export class SmartContract implements ISmartContract {
             .build();
 
         let transaction = new Transaction({
+            sender: Address.Zero(),
             receiver: receiver ? receiver : this.getAddress(),
             value: value,
             gasLimit: gasLimit,

--- a/src/transaction.spec.ts
+++ b/src/transaction.spec.ts
@@ -20,6 +20,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 89,
             value: "0",
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: minGasLimit,
@@ -35,6 +36,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 90,
             value: "0",
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: 80000,
@@ -51,6 +53,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 89,
             value: "0",
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: minGasLimit,
@@ -68,6 +71,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 91,
             value: TokenPayment.egldFromAmount(10),
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: 100000,
@@ -84,6 +88,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 92,
             value: TokenPayment.egldFromBigInteger("123456789000000000000000000000"),
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: 100000,
@@ -100,6 +105,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 0,
             value: 0,
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: 80000,
@@ -117,6 +123,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 89,
             value: 0,
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: minGasLimit,
@@ -135,6 +142,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 92,
             value: TokenPayment.egldFromBigInteger("123456789000000000000000000000"),
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: 500,
             gasLimit: 20,
@@ -156,6 +164,7 @@ describe("test transaction construction", async () => {
         let transaction = new Transaction({
             nonce: 92,
             value: TokenPayment.egldFromBigInteger("123456789000000000000000000000"),
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             data: new TransactionPayload("testdata"),
             gasPrice: 500,
@@ -179,6 +188,7 @@ describe("test transaction construction", async () => {
         const transaction = new Transaction({
             nonce: 90,
             value: new BigNumber("1000000000000000000"),
+            sender: wallets.alice.address,
             receiver: wallets.bob.address,
             gasPrice: minGasPrice,
             gasLimit: 80000,

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -99,7 +99,7 @@ export class Transaction {
     nonce?: INonce;
     value?: ITransactionValue;
     receiver: IAddress;
-    sender?: IAddress;
+    sender: IAddress;
     gasPrice?: IGasPrice;
     gasLimit: IGasLimit;
     data?: ITransactionPayload;
@@ -109,7 +109,7 @@ export class Transaction {
   }) {
     this.nonce = nonce || 0;
     this.value = value || 0;
-    this.sender = sender || Address.Zero();
+    this.sender = sender;
     this.receiver = receiver;
     this.gasPrice = gasPrice || TRANSACTION_MIN_GAS_PRICE;
     this.gasLimit = gasLimit;
@@ -244,6 +244,7 @@ export class Transaction {
       nonce: Number(plainObjectTransaction.nonce),
       value: new BigNumber(plainObjectTransaction.value),
       receiver: Address.fromString(plainObjectTransaction.receiver),
+      sender: Address.fromString(plainObjectTransaction.sender),
       gasPrice: Number(plainObjectTransaction.gasPrice),
       gasLimit: Number(plainObjectTransaction.gasLimit),
       data: new TransactionPayload(atob(plainObjectTransaction.data || "")),

--- a/src/transactionFactory.ts
+++ b/src/transactionFactory.ts
@@ -1,6 +1,7 @@
 import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, ITokenPayment, ITransactionPayload, ITransactionValue } from "./interface";
 import { ESDTNFTTransferPayloadBuilder, ESDTTransferPayloadBuilder, MultiESDTNFTTransferPayloadBuilder } from "./tokenTransferBuilders";
 import { Transaction } from "./transaction";
+import {Address} from "./address";
 
 interface IGasEstimator {
     forEGLDTransfer(dataLength: number): number;
@@ -33,7 +34,7 @@ export class TransactionFactory {
             nonce: args.nonce,
             value: args.value,
             receiver: args.receiver,
-            sender: args.sender,
+            sender: args.sender || Address.Zero(),
             gasPrice: args.gasPrice,
             gasLimit: args.gasLimit || estimatedGasLimit,
             data: args.data,
@@ -60,7 +61,7 @@ export class TransactionFactory {
         return new Transaction({
             nonce: args.nonce,
             receiver: args.receiver,
-            sender: args.sender,
+            sender: args.sender || Address.Zero(),
             gasPrice: args.gasPrice,
             gasLimit: args.gasLimit || estimatedGasLimit,
             data: transactionPayload,


### PR DESCRIPTION
Sender becomes now mandatory in transaction construction. This fixes the issue that a developers forget to set a sender and end up with invalid signatures