### PR TITLE
Update endpoint.ts

### DIFF
--- a/src/smartcontracts/typesystem/endpoint.ts
+++ b/src/smartcontracts/typesystem/endpoint.ts
@@ -26,7 +26,7 @@ export class EndpointDefinition {
         mutability: string,
         payableInTokens: string[],
         inputs: any[],
-        outputs: []
+        outputs: any[]
     }): EndpointDefinition {
         json.name = json.name == null ? NamePlaceholder : json.name;
         json.payableInTokens = json.payableInTokens || [];


### PR DESCRIPTION
Otherwise I'm getting `Type '[{ type: string; }]' is not assignable to type '[]'. Source has 1 element(s) but target allows only 0`

It could probably get strong typing like `{ name: string, type: string, multi_arg: boolean }`, but I am not sure what exactly is allowed there.