### PR TITLE
Set correct options for guarded transactions

### DIFF
--- a/src/accountManagement/accountController.ts
+++ b/src/accountManagement/accountController.ts
@@ -26,6 +26,7 @@ export class AccountController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -42,6 +43,7 @@ export class AccountController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -72,6 +74,7 @@ export class AccountController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;

--- a/src/core/baseController.spec.ts
+++ b/src/core/baseController.spec.ts
@@ -1,0 +1,56 @@
+import { assert } from "chai";
+import { Address } from "./address";
+import { BaseController } from "./baseController";
+import { Transaction } from "./transaction";
+
+class TestableBaseController extends BaseController {
+    public exposeSetTransactionGasOptions(
+        transaction: Transaction,
+        options: { gasLimit?: bigint; gasPrice?: bigint },
+    ): void {
+        this.setTransactionGasOptions(transaction, options);
+    }
+
+    public exposeSetVersionAndOptionsForGuardian(transaction: Transaction): void {
+        this.setVersionAndOptionsForGuardian(transaction);
+    }
+}
+
+describe("BaseController Tests", function () {
+    it("set correct gasLimit", function () {
+        const controller = new TestableBaseController();
+
+        const transaction = new Transaction({
+            sender: Address.newFromBech32("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"),
+            receiver: Address.newFromBech32("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"),
+            gasLimit: 0n,
+            chainID: "D",
+        });
+
+        controller.exposeSetTransactionGasOptions(transaction, { gasLimit: 50000n });
+        assert.equal(transaction.gasLimit, 50000n);
+
+        transaction.guardian = Address.newFromBech32("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
+        transaction.relayer = Address.newFromBech32("erd1kyaqzaprcdnv4luvanah0gfxzzsnpaygsy6pytrexll2urtd05ts9vegu7");
+        controller.exposeSetTransactionGasOptions(transaction, {});
+        assert.equal(transaction.gasLimit, 150000n);
+    });
+
+    it("set correct version and options for guarded transactions", function () {
+        const controller = new TestableBaseController();
+
+        const transaction = new Transaction({
+            sender: Address.newFromBech32("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"),
+            receiver: Address.newFromBech32("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"),
+            gasLimit: 0n,
+            chainID: "D",
+            version: 0,
+            options: 0,
+            guardian: Address.newFromBech32("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"),
+        });
+
+        controller.exposeSetVersionAndOptionsForGuardian(transaction);
+        assert.equal(transaction.version, 2);
+        assert.equal(transaction.options, 2);
+    });
+});

--- a/src/core/baseController.ts
+++ b/src/core/baseController.ts
@@ -1,6 +1,7 @@
 import { Address } from "./address";
 import { EXTRA_GAS_LIMIT_FOR_GUARDED_TRANSACTIONS, EXTRA_GAS_LIMIT_FOR_RELAYED_TRANSACTIONS } from "./constants";
 import { Transaction } from "./transaction";
+import { TransactionComputer } from "./transactionComputer";
 
 export type BaseControllerInput = {
     guardian?: Address;
@@ -28,6 +29,13 @@ export class BaseController {
 
         if (transaction.relayer && !transaction.relayer.isEmpty()) {
             transaction.gasLimit += BigInt(EXTRA_GAS_LIMIT_FOR_RELAYED_TRANSACTIONS);
+        }
+    }
+
+    protected setVersionAndOptionsForGuardian(transaction: Transaction): void {
+        if (transaction.guardian && !transaction.guardian.isEmpty()) {
+            const txComputer = new TransactionComputer();
+            txComputer.applyGuardian(transaction, transaction.guardian);
         }
     }
 }

--- a/src/delegation/delegationController.ts
+++ b/src/delegation/delegationController.ts
@@ -38,6 +38,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -63,6 +64,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -79,6 +81,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -95,6 +98,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -111,6 +115,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -127,6 +132,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -143,6 +149,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -159,6 +166,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -175,6 +183,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -191,6 +200,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -207,6 +217,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -226,6 +237,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -245,6 +257,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -261,6 +274,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -277,6 +291,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -293,6 +308,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -309,6 +325,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -325,6 +342,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -342,6 +360,7 @@ export class DelegationController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
 
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;

--- a/src/smartContracts/smartContractController.ts
+++ b/src/smartContracts/smartContractController.ts
@@ -49,6 +49,7 @@ export class SmartContractController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -74,6 +75,7 @@ export class SmartContractController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -90,6 +92,7 @@ export class SmartContractController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;

--- a/src/tokenManagement/tokenManagementController.ts
+++ b/src/tokenManagement/tokenManagementController.ts
@@ -38,6 +38,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -63,6 +64,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -88,6 +90,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -113,6 +116,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -138,6 +142,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -163,6 +168,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -188,6 +194,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -213,6 +220,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -241,6 +249,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -260,6 +269,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -288,6 +298,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -304,6 +315,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -329,6 +341,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -348,6 +361,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -376,6 +390,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -392,6 +407,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -417,6 +433,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -442,6 +459,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -467,6 +485,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -492,6 +511,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -517,6 +537,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -542,6 +563,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -567,6 +589,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -592,6 +615,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -617,6 +641,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -642,6 +667,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -667,6 +693,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -692,6 +719,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -717,6 +745,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -742,6 +771,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -767,6 +797,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -792,6 +823,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -817,6 +849,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -838,6 +871,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -863,6 +897,7 @@ export class TokenManagementController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;

--- a/src/transfers/transfersControllers.ts
+++ b/src/transfers/transfersControllers.ts
@@ -28,6 +28,7 @@ export class TransfersController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -44,6 +45,7 @@ export class TransfersController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;
@@ -60,6 +62,7 @@ export class TransfersController extends BaseController {
         transaction.relayer = options.relayer ?? Address.empty();
         transaction.nonce = nonce;
         this.setTransactionGasOptions(transaction, options);
+        this.setVersionAndOptionsForGuardian(transaction);
         transaction.signature = await sender.signTransaction(transaction);
 
         return transaction;


### PR DESCRIPTION
When creating guarded transactions using the controllers, the `options` field was not properly set.