### PR TITLE
Fixes after audit

### DIFF
--- a/cookbook/signingObjects.ts
+++ b/cookbook/signingObjects.ts
@@ -78,7 +78,7 @@ import { Account, Address, Message, MessageComputer, Transaction, TransactionCom
         const hash = transactionComputer.computeHashForSigning(transaction);
 
         // sign and apply the signature on the transaction // md-as-comment
-        transaction.signature = await alice.signTransaction(transaction);
+        transaction.signature = await alice.sign(hash);
 
         console.log(transaction.toPlainObject());
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "15.4.1",
+  "version": "16.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "15.4.1",
+      "version": "16.0.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "15.4.1",
+  "version": "16.0.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "author": "MultiversX",
   "homepage": "https://multiversx.com",

--- a/src/abi/codec/binary.spec.ts
+++ b/src/abi/codec/binary.spec.ts
@@ -145,8 +145,8 @@ describe("test binary codec (basic)", () => {
         assert.deepEqual(new BigUIntValue("0xabcdefabcdefabcdef"), new BigUIntValue(BigInt("0xabcdefabcdefabcdef")));
         assert.deepEqual(new U64Value("0xabcdef"), new U64Value(BigInt(0xabcdef)));
         assert.deepEqual(new U32Value("0xabcdef"), new U32Value(BigInt(0xabcdef)));
-        assert.deepEqual(new U16Value("0xabcdef"), new U16Value(BigInt(0xabcdef)));
-        assert.deepEqual(new U8Value("0xabcdef"), new U8Value(BigInt(0xabcdef)));
+        assert.deepEqual(new U16Value("0xabcd"), new U16Value(BigInt(0xabcd)));
+        assert.deepEqual(new U8Value("0xab"), new U8Value(BigInt(0xab)));
 
         assert.deepEqual(
             new BigIntValue(BigInt("0xabcdefabcdefabcdef")),
@@ -154,8 +154,19 @@ describe("test binary codec (basic)", () => {
         );
         assert.deepEqual(new I64Value("0xabcdef"), new I64Value(BigInt(0xabcdef)));
         assert.deepEqual(new I32Value("0xabcdef"), new I32Value(BigInt(0xabcdef)));
-        assert.deepEqual(new I16Value("0xabcdef"), new I16Value(BigInt(0xabcdef)));
-        assert.deepEqual(new I8Value("0xabcdef"), new I8Value(BigInt(0xabcdef)));
+        assert.deepEqual(new I16Value("0x7abc"), new I16Value(BigInt(0x7abc)));
+        assert.deepEqual(new I8Value("0x7f"), new I8Value(BigInt(0x7f)));
+    });
+
+    it("should reject out-of-range fixed-size values when decoding", () => {
+        assert.throws(
+            () => codec.decodeTopLevel<NumericalValue>(Buffer.from([0x01, 0x00]), new U8Type()),
+            errors.ErrInvalidArgument,
+        );
+        assert.throws(
+            () => codec.decodeTopLevel<NumericalValue>(Buffer.from([0x00, 0x80]), new I8Type()),
+            errors.ErrInvalidArgument,
+        );
     });
 
     it("should create bytes and strings, encode and decode", async () => {

--- a/src/abi/nativeSerializer.spec.ts
+++ b/src/abi/nativeSerializer.spec.ts
@@ -37,6 +37,20 @@ import {
 } from "./typesystem";
 
 describe("test native serializer", () => {
+    it("should reject invalid fixed-size numerical arguments", () => {
+        const endpoint = new EndpointDefinition(
+            "foo",
+            [new EndpointParameterDefinition("value", "", new U8Type())],
+            [],
+            new EndpointModifiers("", []),
+        );
+
+        assert.deepEqual(NativeSerializer.nativeToTypedValues([255], endpoint), [new U8Value(255)]);
+        assert.throws(() => NativeSerializer.nativeToTypedValues([-1], endpoint), ErrInvalidArgument);
+        assert.throws(() => NativeSerializer.nativeToTypedValues([256], endpoint), ErrInvalidArgument);
+        assert.throws(() => NativeSerializer.nativeToTypedValues([1.5], endpoint), ErrInvalidArgument);
+    });
+
     it("should perform type inference", async () => {
         const endpointModifiers = new EndpointModifiers("", []);
         const inputParameters = [

--- a/src/abi/typesystem/numerical.ts
+++ b/src/abi/typesystem/numerical.ts
@@ -159,6 +159,11 @@ export class NumericalValue extends PrimitiveValue {
     constructor(type: NumericalType, value: BigNumber.Value | bigint) {
         super(type);
 
+        const originalValue = value;
+        if (typeof value === "number" && Number.isInteger(value) && !Number.isSafeInteger(value)) {
+            throw new errors.ErrInvalidArgument(`unsafe JavaScript integer: ${value}; use bigint or a decimal string`);
+        }
+
         if (typeof value === "bigint") {
             value = value.toString();
         }
@@ -171,8 +176,33 @@ export class NumericalValue extends PrimitiveValue {
             throw new errors.ErrInvalidArgument(`not a number: ${value}`);
         }
 
+        if (!this.value.isFinite()) {
+            throw new errors.ErrInvalidArgument(`not a finite number: ${value}`);
+        }
+
+        if (!this.value.isInteger()) {
+            throw new errors.ErrInvalidArgument(`not an integer: ${value}`);
+        }
+
         if (!this.withSign && this.value.isNegative()) {
             throw new errors.ErrInvalidArgument(`negative, but type is unsigned: ${value}`);
+        }
+
+        if (type.hasFixedSize()) {
+            this.checkFixedSizeRange(type, originalValue);
+        }
+    }
+
+    private checkFixedSizeRange(type: NumericalType, originalValue: BigNumber.Value | bigint): void {
+        const numberOfBits = type.sizeInBytes * 8;
+        const limit = new BigNumber(2).pow(type.withSign ? numberOfBits - 1 : numberOfBits);
+        const minimum = type.withSign ? limit.negated() : new BigNumber(0);
+        const maximum = limit.minus(1);
+
+        if (this.value.isLessThan(minimum) || this.value.isGreaterThan(maximum)) {
+            throw new errors.ErrInvalidArgument(
+                `value out of range for ${type}: ${originalValue}; expected ${minimum.toFixed()} through ${maximum.toFixed()}`,
+            );
         }
     }
 

--- a/src/abi/typesystem/types.spec.ts
+++ b/src/abi/typesystem/types.spec.ts
@@ -7,7 +7,22 @@ import { BytesType, BytesValue } from "./bytes";
 import { OptionType } from "./generic";
 import { ManagedDecimalType } from "./managedDecimal";
 import { ManagedDecimalSignedType } from "./managedDecimalSigned";
-import { I64Type, NumericalValue, U16Type, U32Type, U32Value } from "./numerical";
+import {
+    BigIntValue,
+    BigUIntValue,
+    I16Value,
+    I32Value,
+    I64Type,
+    I64Value,
+    I8Value,
+    NumericalValue,
+    U16Type,
+    U16Value,
+    U32Type,
+    U32Value,
+    U64Value,
+    U8Value,
+} from "./numerical";
 import { StringType } from "./string";
 import { TypeExpressionParser } from "./typeExpressionParser";
 import { NullType, PrimitiveType, Type } from "./types";
@@ -18,6 +33,99 @@ describe("test types", () => {
     it("for numeric values, should throw error when invalid input", () => {
         assert.throw(() => new U32Value(new BigNumber(-42)), errors.ErrInvalidArgument);
         assert.throw(() => new NumericalValue(new U16Type(), <any>{ foobar: 42 }), errors.ErrInvalidArgument);
+    });
+
+    it("should enforce fixed-size numerical boundaries", () => {
+        const cases: Array<{
+            create: (value: BigNumber.Value | bigint) => NumericalValue;
+            minimum: string;
+            maximum: string;
+            belowMinimum: string;
+            aboveMaximum: string;
+        }> = [
+            {
+                create: (value) => new U8Value(value),
+                minimum: "0",
+                maximum: "255",
+                belowMinimum: "-1",
+                aboveMaximum: "256",
+            },
+            {
+                create: (value) => new I8Value(value),
+                minimum: "-128",
+                maximum: "127",
+                belowMinimum: "-129",
+                aboveMaximum: "128",
+            },
+            {
+                create: (value) => new U16Value(value),
+                minimum: "0",
+                maximum: "65535",
+                belowMinimum: "-1",
+                aboveMaximum: "65536",
+            },
+            {
+                create: (value) => new I16Value(value),
+                minimum: "-32768",
+                maximum: "32767",
+                belowMinimum: "-32769",
+                aboveMaximum: "32768",
+            },
+            {
+                create: (value) => new U32Value(value),
+                minimum: "0",
+                maximum: "4294967295",
+                belowMinimum: "-1",
+                aboveMaximum: "4294967296",
+            },
+            {
+                create: (value) => new I32Value(value),
+                minimum: "-2147483648",
+                maximum: "2147483647",
+                belowMinimum: "-2147483649",
+                aboveMaximum: "2147483648",
+            },
+            {
+                create: (value) => new U64Value(value),
+                minimum: "0",
+                maximum: "18446744073709551615",
+                belowMinimum: "-1",
+                aboveMaximum: "18446744073709551616",
+            },
+            {
+                create: (value) => new I64Value(value),
+                minimum: "-9223372036854775808",
+                maximum: "9223372036854775807",
+                belowMinimum: "-9223372036854775809",
+                aboveMaximum: "9223372036854775808",
+            },
+        ];
+
+        for (const testCase of cases) {
+            assert.doesNotThrow(() => testCase.create(testCase.minimum));
+            assert.doesNotThrow(() => testCase.create(testCase.maximum));
+            assert.throws(() => testCase.create(testCase.belowMinimum), errors.ErrInvalidArgument);
+            assert.throws(() => testCase.create(testCase.aboveMaximum), errors.ErrInvalidArgument);
+        }
+    });
+
+    it("should only accept finite integers for arbitrary-size numerical values", () => {
+        assert.doesNotThrow(() => new BigUIntValue("1e100"));
+        assert.doesNotThrow(() => new BigIntValue("-1e100"));
+
+        assert.throws(() => new BigUIntValue("1.5"), errors.ErrInvalidArgument);
+        assert.throws(() => new BigIntValue("-1.5"), errors.ErrInvalidArgument);
+        assert.throws(() => new BigUIntValue(NaN), errors.ErrInvalidArgument);
+        assert.throws(() => new BigUIntValue(Infinity), errors.ErrInvalidArgument);
+        assert.throws(() => new BigIntValue(-Infinity), errors.ErrInvalidArgument);
+    });
+
+    it("should reject unsafe JavaScript integer inputs", () => {
+        const unsafeNumber = Number.MAX_SAFE_INTEGER + 1;
+
+        assert.throws(() => new U64Value(unsafeNumber), errors.ErrInvalidArgument);
+        assert.doesNotThrow(() => new U64Value(unsafeNumber.toString()));
+        assert.doesNotThrow(() => new U64Value(9007199254740992n));
     });
 
     it("should be assignable from", () => {

--- a/src/core/transactionOnNetwork.ts
+++ b/src/core/transactionOnNetwork.ts
@@ -123,7 +123,7 @@ export class TransactionOnNetwork {
         result.gasPrice = BigInt(originalTx.gasPrice) || 0n;
         result.gasLimit = BigInt(originalTx.gasLimit) || 0n;
         result.function = "";
-        result.data = originalTx.data ? Buffer.from(originalTx.data?.toString()) : Buffer.from("");
+        result.data = originalTx.data ? Buffer.from(originalTx.data) : Buffer.from("");
         result.version = originalTx.version || 1;
         result.options = originalTx.options || 0;
         result.timestamp = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,5 @@ export * from "./smartContracts";
 export * from "./tokenManagement";
 export * from "./transactionsOutcomeParsers";
 export * from "./transfers";
+export * from "./validators";
 export * from "./wallet";

--- a/src/networkProviders/accountAwaiter.ts
+++ b/src/networkProviders/accountAwaiter.ts
@@ -34,13 +34,13 @@ export class AccountAwaiter {
         this.fetcher = options.fetcher;
 
         this.pollingIntervalInMilliseconds =
-            options.pollingIntervalInMilliseconds ?? DEFAULT_ACCOUNT_AWAITING_POLLING_TIMEOUT_IN_MILLISECONDS;
+            options.pollingIntervalInMilliseconds || DEFAULT_ACCOUNT_AWAITING_POLLING_TIMEOUT_IN_MILLISECONDS;
 
         this.timeoutIntervalInMilliseconds =
-            options.timeoutIntervalInMilliseconds ?? DEFAULT_ACCOUNT_AWAITING_TIMEOUT_IN_MILLISECONDS;
+            options.timeoutIntervalInMilliseconds || DEFAULT_ACCOUNT_AWAITING_TIMEOUT_IN_MILLISECONDS;
 
         this.patienceTimeInMilliseconds =
-            options.patienceTimeInMilliseconds ?? DEFAULT_ACCOUNT_AWAITING_PATIENCE_IN_MILLISECONDS;
+            options.patienceTimeInMilliseconds || DEFAULT_ACCOUNT_AWAITING_PATIENCE_IN_MILLISECONDS;
     }
 
     /**

--- a/src/networkProviders/accounts.ts
+++ b/src/networkProviders/accounts.ts
@@ -1,4 +1,3 @@
-import { BytesValue } from "../abi";
 import { Address, CodeMetadata } from "../core";
 import { BlockCoordinates } from "./blocks";
 
@@ -33,11 +32,11 @@ export class AccountOnNetwork {
         result.address = payload["address"] ? Address.newFromBech32(payload["address"]) : Address.empty();
         result.nonce = BigInt(payload["nonce"] || 0);
         result.balance = BigInt(payload["balance"] || 0);
-        result.userName = payload["username"] || undefined;
+        result.userName = payload["username"] || "";
 
         result.contractCodeHash = payload["codeHash"] || "";
         result.contractCode = Buffer.from(payload["code"] || "");
-        result.contractDeveloperReward = payload["developerReward"] || 0n;
+        result.contractDeveloperReward = BigInt(payload["developerReward"] || 0);
         result.contractOwnerAddress = payload["ownerAddress"]
             ? Address.newFromBech32(payload["ownerAddress"])
             : undefined;
@@ -72,7 +71,7 @@ export class AccountOnNetwork {
         }
         result.contractCodeHash = payload["codeHash"] || "";
         result.contractCode = Buffer.from(payload["code"] || "");
-        result.contractDeveloperReward = payload["developerReward"] || 0n;
+        result.contractDeveloperReward = BigInt(payload["developerReward"] || 0);
         result.contractOwnerAddress = payload["ownerAddress"]
             ? Address.newFromBech32(payload["ownerAddress"])
             : undefined;
@@ -146,7 +145,7 @@ export class AccountStorageEntry {
 
         result.raw = payload;
         result.key = key;
-        result.value = BytesValue.fromHex(value).toString();
+        result.value = value;
 
         return result;
     }

--- a/src/networkProviders/accounts.ts
+++ b/src/networkProviders/accounts.ts
@@ -54,7 +54,7 @@ export class AccountOnNetwork {
         result.address = payload["address"] ? Address.newFromBech32(payload["address"]) : Address.empty();
         result.nonce = BigInt(payload["nonce"] || 0);
         result.balance = BigInt(payload["balance"] || 0);
-        result.userName = payload["username"] || undefined;
+        result.userName = payload["username"] || "";
 
         const codeMetadata = payload["codeMetadata"] ?? null;
         result.isContractUpgradable = false;

--- a/src/networkProviders/apiNetworkProvider.dev.net.spec.ts
+++ b/src/networkProviders/apiNetworkProvider.dev.net.spec.ts
@@ -47,14 +47,14 @@ describe("ApiNetworkProvider Tests", function () {
         const result1 = await apiProvider.getAccount(address1);
 
         assert.equal(result1.address.toBech32(), "erd1487vz5m4zpxjyqw4flwa3xhnkzg4yrr3mkzf5sf0zgt94hjprc8qazcccl");
-        assert.isUndefined(result1.userName);
+        assert.equal(result1.userName, "");
         assert.isUndefined(result1.contractOwnerAddress);
 
         const address2 = Address.newFromBech32("erd1qqqqqqqqqqqqqpgq076flgeualrdu5jyyj60snvrh7zu4qrg05vqez5jen");
         const result2 = await apiProvider.getAccount(address2);
 
         assert.equal(result2.address.toBech32(), "erd1qqqqqqqqqqqqqpgq076flgeualrdu5jyyj60snvrh7zu4qrg05vqez5jen");
-        assert.isUndefined(result2.userName);
+        assert.equal(result2.userName, "");
         assert.equal(
             result2.contractOwnerAddress?.toBech32(),
             "erd1wzx0tak22f2me4g7wpxfae2w3htfue7khrg28fy6wu8x9hzq05vqm8qhnm",
@@ -299,7 +299,7 @@ describe("ApiNetworkProvider Tests", function () {
         transaction = new Transaction({
             sender: bob.address,
             receiver: Address.newFromBech32("erd1qqqqqqqqqqqqqpgq076flgeualrdu5jyyj60snvrh7zu4qrg05vqez5jen"),
-            gasLimit: 10000000n,
+            gasLimit: 1500000n,
             chainID: "D",
             gasPrice: 1000000000n,
             version: 2,

--- a/src/networkProviders/apiNetworkProvider.ts
+++ b/src/networkProviders/apiNetworkProvider.ts
@@ -121,7 +121,7 @@ export class ApiNetworkProvider implements INetworkProvider {
         }
         const response = await this.doPostGeneric(url, transaction);
         const data = response["data"] ?? {};
-        return TransactionOnNetwork.fromSimulateResponse(transaction, data["result"] ?? {});
+        return TransactionOnNetwork.fromSimulateResponse(tx, data["result"] ?? {});
     }
 
     async estimateTransactionCost(tx: Transaction): Promise<TransactionCostResponse> {

--- a/src/networkProviders/blocks.ts
+++ b/src/networkProviders/blocks.ts
@@ -73,7 +73,7 @@ export class BlockCoordinates {
         const result = new BlockCoordinates();
         const value = payload["blockInfo"] || {};
 
-        result.nonce = value["nonce"] || 0n;
+        result.nonce = BigInt(value["nonce"] || 0);
         result.hash = value["hash"] || "";
         result.rootHash = value["rootHash"] || "";
 

--- a/src/networkProviders/providers.dev.net.spec.ts
+++ b/src/networkProviders/providers.dev.net.spec.ts
@@ -214,11 +214,11 @@ describe("test network providers on devnet: Proxy and API", function () {
         assert.exists(proxyResponse.logs);
         assert.exists(apiResponse.logs.events);
         assert.exists(proxyResponse.logs.events);
-        assert.equal(Buffer.from(apiResponse.logs.events[0].topics[0]).toString("hex"), "414c4943452d353632376631");
-        assert.equal(Buffer.from(apiResponse.logs.events[0].topics[1]).toString("hex"), "");
-        assert.equal(Buffer.from(apiResponse.logs.events[0].topics[2]).toString("hex"), "01");
+        assert.equal(Buffer.from(apiResponse.logs.events[1].topics[0]).toString("hex"), "414c4943452d353632376631");
+        assert.equal(Buffer.from(apiResponse.logs.events[1].topics[1]).toString("hex"), "");
+        assert.equal(Buffer.from(apiResponse.logs.events[1].topics[2]).toString("hex"), "01");
         assert.equal(
-            Buffer.from(apiResponse.logs.events[0].topics[3]).toString("hex"),
+            Buffer.from(apiResponse.logs.events[1].topics[3]).toString("hex"),
             "0000000000000000050032e141d21536e2dfc3d64b9e7dd0c2c53f201dc469e1",
         );
         assert.equal(

--- a/src/networkProviders/proxyNetworkProvider.dev.net.spec.ts
+++ b/src/networkProviders/proxyNetworkProvider.dev.net.spec.ts
@@ -114,6 +114,9 @@ describe("ProxyNetworkProvider Tests", function () {
         const address = Address.newFromBech32("erd1487vz5m4zpxjyqw4flwa3xhnkzg4yrr3mkzf5sf0zgt94hjprc8qazcccl");
         const tokens = await proxy.getNonFungibleTokensOfAccount(address);
         assert.isTrue(tokens.length > 0);
+        tokens.forEach((token) => {
+            assert.isTrue(token.raw.type !== "FungibleESDT");
+        });
 
         const filtered = tokens.filter((token) => token.token.identifier === "NFTEST-ec88b8-01");
         assert.equal(filtered.length, 1);

--- a/src/networkProviders/proxyNetworkProvider.dev.net.spec.ts
+++ b/src/networkProviders/proxyNetworkProvider.dev.net.spec.ts
@@ -52,14 +52,14 @@ describe("ProxyNetworkProvider Tests", function () {
         const result1 = await proxy.getAccount(address1);
 
         assert.equal(result1.address.toBech32(), "erd1487vz5m4zpxjyqw4flwa3xhnkzg4yrr3mkzf5sf0zgt94hjprc8qazcccl");
-        assert.isUndefined(result1.userName);
+        assert.equal(result1.userName, "");
         assert.isUndefined(result1.contractOwnerAddress);
 
         const address2 = Address.newFromBech32("erd1qqqqqqqqqqqqqpgq076flgeualrdu5jyyj60snvrh7zu4qrg05vqez5jen");
         const result2 = await proxy.getAccount(address2);
 
         assert.equal(result2.address.toBech32(), "erd1qqqqqqqqqqqqqpgq076flgeualrdu5jyyj60snvrh7zu4qrg05vqez5jen");
-        assert.isUndefined(result2.userName);
+        assert.equal(result2.userName, "");
         assert.equal(
             result2.contractOwnerAddress?.toBech32(),
             "erd1wzx0tak22f2me4g7wpxfae2w3htfue7khrg28fy6wu8x9hzq05vqm8qhnm",
@@ -302,7 +302,7 @@ describe("ProxyNetworkProvider Tests", function () {
         transaction = new Transaction({
             sender: bob.address,
             receiver: Address.newFromBech32("erd1qqqqqqqqqqqqqpgq076flgeualrdu5jyyj60snvrh7zu4qrg05vqez5jen"),
-            gasLimit: 10000000n,
+            gasLimit: 1500000n,
             chainID: "D",
             gasPrice: 1000000000n,
             version: 2,
@@ -361,7 +361,11 @@ describe("ProxyNetworkProvider Tests", function () {
         transaction.nonce = nonce;
         transaction.signature = await bob.signTransaction(transaction);
         let hash = await proxy.sendTransaction(transaction);
-        let transactionOnNetwork = await proxy.awaitTransactionCompleted(hash);
+        let transactionOnNetwork = await proxy.awaitTransactionCompleted(hash, {
+            pollingIntervalInMilliseconds: 6000,
+            timeoutInMilliseconds: 50000,
+            patienceInMilliseconds: 0,
+        });
         assert.isTrue(transactionOnNetwork.status.isCompleted());
 
         transaction = new Transaction({

--- a/src/networkProviders/proxyNetworkProvider.ts
+++ b/src/networkProviders/proxyNetworkProvider.ts
@@ -59,7 +59,7 @@ export class ProxyNetworkProvider implements INetworkProvider {
         let response;
         if (args.blockHash) {
             response = await this.doGetGeneric(`block/${args.shard}/by-hash/${args.blockHash}`);
-        } else if (args.blockNonce) {
+        } else if (args.blockNonce !== undefined) {
             response = await this.doGetGeneric(`block/${args.shard}/by-nonce/${args.blockNonce}`);
         } else throw new Error("Block hash or block nonce not provided.");
         return BlockOnNetwork.fromHttpResponse(response.block);
@@ -68,7 +68,7 @@ export class ProxyNetworkProvider implements INetworkProvider {
     async getLatestBlock(shard: number = METACHAIN_ID): Promise<BlockOnNetwork> {
         const blockNonce = (await this.getNetworkStatus(shard)).blockNonce;
         const response = await this.doGetGeneric(`block/${shard}/by-nonce/${blockNonce}`);
-        return BlockOnNetwork.fromHttpResponse(response);
+        return BlockOnNetwork.fromHttpResponse(response.block);
     }
 
     async getAccount(address: Address): Promise<AccountOnNetwork> {
@@ -126,7 +126,7 @@ export class ProxyNetworkProvider implements INetworkProvider {
             url = "transaction/simulate";
         }
         const response = await this.doPostGeneric(url, transaction);
-        return TransactionOnNetwork.fromSimulateResponse(transaction, response["result"] ?? {});
+        return TransactionOnNetwork.fromSimulateResponse(tx, response["result"] ?? {});
     }
 
     async estimateTransactionCost(tx: Transaction): Promise<TransactionCostResponse> {

--- a/src/networkProviders/tokens.ts
+++ b/src/networkProviders/tokens.ts
@@ -109,7 +109,10 @@ export class TokenAmountOnNetwork {
 
         result.raw = payload;
         result.amount = BigInt(payload["balance"] ?? 0);
-        result.token = new Token({ identifier: payload["tokenIdentifier"] ?? "", nonce: payload["nonce"] ?? 0 });
+        result.token = new Token({
+            identifier: payload["tokenIdentifier"] ?? "",
+            nonce: BigInt(payload["nonce"] ?? 0),
+        });
 
         return result;
     }
@@ -119,7 +122,7 @@ export class TokenAmountOnNetwork {
 
         result.raw = payload;
         result.amount = BigInt(payload["balance"] ?? 0);
-        result.token = new Token({ identifier: payload["identifier"] ?? "", nonce: payload["nonce"] ?? 0 });
+        result.token = new Token({ identifier: payload["identifier"] ?? "", nonce: BigInt(payload["nonce"] ?? 0) });
 
         return result;
     }

--- a/src/tokenManagement/tokenManagementController.ts
+++ b/src/tokenManagement/tokenManagementController.ts
@@ -460,7 +460,7 @@ export class TokenManagementController extends BaseController {
         return this.parser.parseWipe(transactionOnNetwork);
     }
 
-    async createTransactionForLocaMinting(
+    async createTransactionForLocalMinting(
         sender: IAccount,
         nonce: bigint,
         options: resources.LocalMintInput & BaseControllerInput,

--- a/src/tokenManagement/tokenManagementTransactionsFactory.ts
+++ b/src/tokenManagement/tokenManagementTransactionsFactory.ts
@@ -327,7 +327,7 @@ export class TokenManagementTransactionsFactory extends BaseFactory {
         const args = [new StringValue(options.tokenIdentifier), new AddressValue(options.user)];
 
         options.removeRoleLocalMint ? args.push(new StringValue("ESDTRoleLocalMint")) : 0;
-        options.removeRoleESDTTransferRole ? args.push(new StringValue("ESDTRoleLocalBurn")) : 0;
+        options.removeRoleLocalBurn ? args.push(new StringValue("ESDTRoleLocalBurn")) : 0;
         options.removeRoleESDTTransferRole ? args.push(new StringValue("ESDTTransferRole")) : 0;
 
         const dataParts = ["unSetSpecialRole", ...this.argSerializer.valuesToStrings(args)];
@@ -517,7 +517,7 @@ export class TokenManagementTransactionsFactory extends BaseFactory {
 
         const transaction = new Transaction({
             sender: sender,
-            receiver: sender,
+            receiver: this.esdtContractAddress,
             chainID: this.config.chainID,
             gasLimit: 0n,
         });
@@ -536,7 +536,7 @@ export class TokenManagementTransactionsFactory extends BaseFactory {
 
         const transaction = new Transaction({
             sender: sender,
-            receiver: sender,
+            receiver: this.esdtContractAddress,
             chainID: this.config.chainID,
             gasLimit: 0n,
         });
@@ -558,7 +558,7 @@ export class TokenManagementTransactionsFactory extends BaseFactory {
 
         const transaction = new Transaction({
             sender: sender,
-            receiver: sender,
+            receiver: this.esdtContractAddress,
             chainID: this.config.chainID,
             gasLimit: 0n,
         });
@@ -580,7 +580,7 @@ export class TokenManagementTransactionsFactory extends BaseFactory {
 
         const transaction = new Transaction({
             sender: sender,
-            receiver: sender,
+            receiver: this.esdtContractAddress,
             chainID: this.config.chainID,
             gasLimit: 0n,
         });
@@ -602,7 +602,7 @@ export class TokenManagementTransactionsFactory extends BaseFactory {
 
         const transaction = new Transaction({
             sender: sender,
-            receiver: sender,
+            receiver: this.esdtContractAddress,
             chainID: this.config.chainID,
             gasLimit: 0n,
         });

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,2 +1,3 @@
 export * from "./resources";
+export * from "./validatorsController";
 export * from "./validatorsTransactionsFactory";

--- a/src/validators/resources.ts
+++ b/src/validators/resources.ts
@@ -11,5 +11,5 @@ export type RestakingInput = { publicKeys: ValidatorPublicKey[] };
 export type UnbondingInput = { publicKeys: ValidatorPublicKey[] };
 export type UnbondingTokensInput = { amount: bigint };
 export type UnjailingInput = { publicKeys: ValidatorPublicKey[]; amount: bigint };
-export type NewDelegationContractInput = { maxCap: bigint; fee: bigint };
+export type NewDelegationContractFromValidatorDataInput = { maxCap: bigint; fee: bigint };
 export type MergeValidatorToDelegationInput = { delegationAddress: Address };

--- a/src/validators/validatorsController.ts
+++ b/src/validators/validatorsController.ts
@@ -183,7 +183,7 @@ export class ValidatorsController extends BaseController {
     async createTransactionForNewDelegationContractFromValidatorData(
         sender: IAccount,
         nonce: bigint,
-        options: resources.NewDelegationContractInput & BaseControllerInput,
+        options: resources.NewDelegationContractFromValidatorDataInput & BaseControllerInput,
     ): Promise<Transaction> {
         const transaction = await this.factory.createTransactionForNewDelegationContractFromValidatorData(
             sender.address,

--- a/src/validators/validatorsTransactionsFactory.ts
+++ b/src/validators/validatorsTransactionsFactory.ts
@@ -327,7 +327,7 @@ export class ValidatorsTransactionsFactory extends BaseFactory {
 
     async createTransactionForNewDelegationContractFromValidatorData(
         sender: Address,
-        options: resources.NewDelegationContractInput,
+        options: resources.NewDelegationContractFromValidatorDataInput,
     ): Promise<Transaction> {
         const dataParts = [
             "makeNewContractFromValidatorData",


### PR DESCRIPTION
**Breaking changes**

- Renames `createTransactionForLocaMinting()` to `createTransactionForLocalMinting()`.
- Renames `NewDelegationContractInput` to `NewDelegationContractFromValidatorDataInput` and `validators` package is now exported.

**Other changes**

- Enforces valid integer ranges for fixed-width ABI numerical types.
- Corrects simulated transaction data, latest-block parsing, and network `bigint` conversions.
- Fixes token-management transaction receivers, role removal, and local-minting naming.
- Exposes validator controllers, factories, and resources from the package root.
- Corrects account/storage response defaults and polling-option handling.